### PR TITLE
Fixes webhook action group receiver examples to use correct parameter

### DIFF
--- a/azps-1.0.0/Az.Monitor/New-AzActionGroupReceiver.md
+++ b/azps-1.0.0/Az.Monitor/New-AzActionGroupReceiver.md
@@ -54,7 +54,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.

--- a/azps-1.1.0/Az.Monitor/New-AzActionGroupReceiver.md
+++ b/azps-1.1.0/Az.Monitor/New-AzActionGroupReceiver.md
@@ -54,7 +54,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.

--- a/azps-1.2.0/Az.Monitor/New-AzActionGroupReceiver.md
+++ b/azps-1.2.0/Az.Monitor/New-AzActionGroupReceiver.md
@@ -54,7 +54,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.

--- a/azurermps-2.3.0/AzureRm.Insights/New-AzureRmActionGroupReceiver.md
+++ b/azurermps-2.3.0/AzureRm.Insights/New-AzureRmActionGroupReceiver.md
@@ -52,7 +52,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.

--- a/azurermps-4.4.1/AzureRM.Insights/New-AzureRmActionGroupReceiver.md
+++ b/azurermps-4.4.1/AzureRM.Insights/New-AzureRmActionGroupReceiver.md
@@ -54,7 +54,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.

--- a/azurermps-5.7.0/AzureRM.Insights/New-AzureRmActionGroupReceiver.md
+++ b/azurermps-5.7.0/AzureRM.Insights/New-AzureRmActionGroupReceiver.md
@@ -54,7 +54,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.

--- a/azurermps-6.13.0/AzureRM.Insights/New-AzureRmActionGroupReceiver.md
+++ b/azurermps-6.13.0/AzureRM.Insights/New-AzureRmActionGroupReceiver.md
@@ -54,7 +54,7 @@ This command creates a new SMS receiver in memory.
 
 ### Example 3: Create a new webhook receiver in memory.
 ```
-PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -SMSReceiver -ServiceUri 'http://test.com'
+PS C:\>$webhookReceiver = New-AzureRmActionGroupReceiver -Name 'webhookReceiver1' -WebhookReceiver -ServiceUri 'http://test.com'
 ```
 
 This command creates a new webhook receiver in memory.


### PR DESCRIPTION
I noticed that the action group webhook receiver examples use the `SMSReceiver` parameter rather than the `WebhookReceiver` parameter.