### PR TITLE
add clarification on what to provide for username

### DIFF
--- a/docs-conceptual/azps-1.5.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-1.5.0/create-azure-service-principal-azureps.md
@@ -133,7 +133,7 @@ Get-AzRoleAssignment -ServicePrinicpalName ServicePrincipalName
 
 Test the new service principal's credentials and permissions by signing in. To sign in with a service principal, you need the `applicationId` value associated with it, and the tenant it was created under.
 
-To sign in with a service principal using a password:
+To sign in with a service principal using a password (provide the ApplicationId when prompted for User Name):
 
 ```azurepowershell-interactive
 # Use the application ID as the username, and the secret as password


### PR DESCRIPTION
added some clarifying text to the example. took me a while to discover that application id should be used in place of UserName and not the  ServicePrincipalName