### PR TITLE
chore: Remove azurestackps-1.7.1 mapping

### DIFF
--- a/mapping/monikerMapping.json
+++ b/mapping/monikerMapping.json
@@ -67,12 +67,6 @@
         "packageRoot": "azurestackps-1.6.0",
         "referenceTocUrl": "/powershell/module/azure-stack/toc.json"
     },
-    "azurestackps-1.7.1": {
-        "conceptualToc": "docs-conceptual/azurestackps-1.7.1/toc.yml",
-        "conceptualTocUrl": "/powershell/azure/azure-stack/toc.json",
-        "packageRoot": "azurestackps-1.7.1",
-        "referenceTocUrl": "/powershell/module/azure-stack/toc.json"
-    },
     "azurestackps-1.7.2": {
         "conceptualToc": "docs-conceptual/azurestackps-1.7.2/toc.yml",
         "conceptualTocUrl": "/powershell/azure/azure-stack/toc.json",


### PR DESCRIPTION

Was renamed in #1067 and is causing build warnings