### PR TITLE
-TenantId => -Tenant

### DIFF
--- a/docs-conceptual/azps-2.5.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-2.5.0/create-azure-service-principal-azureps.md
@@ -153,7 +153,7 @@ Certificate-based authentication requires that Azure PowerShell can retrieve inf
 store based on a certificate thumbprint.
 
 ```azurepowershell-interactive
-Connect-AzAccount -ServicePrincipal -TenantId $tenantId -CertificateThumbprint <thumbprint>
+Connect-AzAccount -ServicePrincipal -Tenant <tenant ID> -CertificateThumbprint <thumbprint>
 ```
 
 For instructions on importing a certificate into a credential store accessible by PowerShell, see [Sign in with Azure PowerShell](authenticate-azureps.md#sp-signin)


### PR DESCRIPTION
`-TenantId` isn't a valid parameter, so I've updated it to `-Tenant` and used the same placeholder for `<tenant ID>` as is used in the previous example.