### PR TITLE
Remove duplicate AzureRm from cmdlet names

### DIFF
--- a/azurermps-4.4.1/AzureRM.ApiManagement/Remove-AzureRmApiManagementApi.md
+++ b/azurermps-4.4.1/AzureRM.ApiManagement/Remove-AzureRmApiManagementApi.md
@@ -21,13 +21,13 @@ Remove-AzureRmApiManagementApi -Context <PsApiManagementContext> -ApiId <String>
 ```
 
 ## DESCRIPTION
-The **Remove-AzureRmAzureRmApiManagementApi** cmdlet removes an existing API.
+The **Remove-AzureRmApiManagementApi** cmdlet removes an existing API.
 
 ## EXAMPLES
 
 ### Example 1: Remove an API
 ```
-PS C:\>Remove-AzureRmAzureRmApiManagementApi -Context $ApiMgmtContext -ApiId "0123456789"
+PS C:\>Remove-AzureRmApiManagementApi -Context $ApiMgmtContext -ApiId "0123456789"
 ```
 
 This command removes the API with the specified ID.

--- a/azurermps-5.7.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApi.md
+++ b/azurermps-5.7.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApi.md
@@ -20,14 +20,14 @@ Remove-AzureRmApiManagementApi -Context <PsApiManagementContext> -ApiId <String>
 ```
 
 ## DESCRIPTION
-The **Remove-AzureRmAzureRmApiManagementApi** cmdlet removes an existing API.
+The **Remove-AzureRmApiManagementApi** cmdlet removes an existing API.
 
 ## EXAMPLES
 
 ### Example 1: Remove an API
 ```
 PS C:\>$apimContext = New-AzureRmApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzureRmAzureRmApiManagementApi -Context $apimContext -ApiId "0123456789"
+PS C:\>Remove-AzureRmApiManagementApi -Context $apimContext -ApiId "0123456789"
 ```
 
 This command removes the API with the specified ID.

--- a/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApi.md
+++ b/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApi.md
@@ -21,14 +21,14 @@ Remove-AzureRmApiManagementApi -Context <PsApiManagementContext> -ApiId <String>
 ```
 
 ## DESCRIPTION
-The **Remove-AzureRmAzureRmApiManagementApi** cmdlet removes an existing API.
+The **Remove-AzureRmApiManagementApi** cmdlet removes an existing API.
 
 ## EXAMPLES
 
 ### Example 1: Remove an API
 ```powershell
 PS C:\>$apimContext = New-AzureRmApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzureRmAzureRmApiManagementApi -Context $apimContext -ApiId "0123456789"
+PS C:\>Remove-AzureRmApiManagementApi -Context $apimContext -ApiId "0123456789"
 ```
 
 This command removes the API with the specified ID.

--- a/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApiRelease.md
+++ b/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApiRelease.md
@@ -28,14 +28,14 @@ Remove-AzureRmApiManagementApiRelease -InputObject <PsApiManagementApiRelease> [
 
 ## DESCRIPTION
 
-The **Remove-AzureRmAzureRmApiManagementApiRelease** cmdlet removes an existing API Release.
+The **Remove-AzureRmApiManagementApiRelease** cmdlet removes an existing API Release.
 
 ## EXAMPLES
 
 ### Example 1: Remove an API Release
 ```powershell
 PS C:\>$apimContext = New-AzureRmApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzureRmAzureRmApiManagementApiRelease -Context $apimContext -ApiId "echo-api" -ReleaseId "2"
+PS C:\>Remove-AzureRmApiManagementApiRelease -Context $apimContext -ApiId "echo-api" -ReleaseId "2"
 ```
 
 This command removes the API Release with the specified ApiId and ReleaseId.

--- a/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApiRevision.md
+++ b/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApiRevision.md
@@ -34,7 +34,7 @@ The cmdlet **Remove-AzureRmApiManagementApiRevision** removes a particular API r
 ### Example 1: Remove an API Revision
 ```powershell
 PS C:\>$apimContext = New-AzureRmApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzureRmAzureRmApiManagementApiRevision -Context $apimContext -ApiId "echo-api" -ApiRevision "2"
+PS C:\>Remove-AzureRmApiManagementApiRevision -Context $apimContext -ApiId "echo-api" -ApiRevision "2"
 ```
 
 This command removes the `2` revision of the API `echo-api` from API Management service.

--- a/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApiVersionSet.md
+++ b/azurermps-6.13.0/AzureRM.ApiManagement/Remove-AzureRmApiManagementApiVersionSet.md
@@ -28,7 +28,7 @@ Remove-AzureRmApiManagementApiVersionSet -InputObject <PsApiManagementApiVersion
 
 ## DESCRIPTION
 
-The **Remove-AzureRmAzureRmApiManagementApiVersionSet** cmdlet removes an existing API Version Set.
+The **Remove-AzureRmApiManagementApiVersionSet** cmdlet removes an existing API Version Set.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Replaced all occurrences of `AzureRmAzureRm` with `AzureRm`.