### PR TITLE
Fixes #1385 - Clarified installation instructions

### DIFF
--- a/docs-conceptual/azps-3.8.0/install-az-ps.md
+++ b/docs-conceptual/azps-3.8.0/install-az-ps.md
@@ -87,7 +87,7 @@ if (Get-Module -Name AzureRM -ListAvailable) {
 ```
 
 The Az module is a rollup module for the Azure PowerShell cmdlets. Installing it downloads all of
-the available Az PowerShell modules, and makes their cmdlets available for use.
+the generally available Az PowerShell modules, and makes their cmdlets available for use.
 
 ## Install offline
 

--- a/docs-conceptual/azps-3.8.0/install-az-ps.md
+++ b/docs-conceptual/azps-3.8.0/install-az-ps.md
@@ -8,41 +8,52 @@ ms.date: 02/26/2020
 
 # Install Azure PowerShell
 
-This article explains how to install the Azure PowerShell modules using [PowerShellGet](/powershell/scripting/gallery/installing-psget). These
-instructions work on Windows, macOS, and Linux platforms.
+This article explains how to install the Azure PowerShell modules using
+[PowerShellGet](/powershell/scripting/gallery/installing-psget). These instructions work on Windows,
+macOS, and Linux platforms.
 
 Azure PowerShell is also available in Azure [Cloud Shell](/azure/cloud-shell/overview) and is now
 preinstalled in [Docker images](azureps-in-docker.md).
 
 ## Requirements
 
-Azure PowerShell works with PowerShell 5.1 or higher on Windows, or PowerShell Core 6.x and later on
-all platforms. You should install the
-[latest version of PowerShell Core](/powershell/scripting/install/installing-powershell#powershell-core)
-available for your operating system. Azure PowerShell has no additional requirements when run on
-PowerShell Core.
+Azure PowerShell works with PowerShell 7.x and later on all platforms. It is also supported with
+PowerShell 5.1 on Windows. Install the
+[latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
+your operating system. Azure PowerShell has no additional requirements when run on PowerShell 7.x
+and later.
 
 To check your PowerShell version, run the command:
 
-```powershell-interactive
+```azurepowershell-interactive
 $PSVersionTable.PSVersion
 ```
 
 To use Azure PowerShell in PowerShell 5.1 on Windows:
 
 1. Update to
-   [Windows PowerShell 5.1](/powershell/scripting/install/installing-windows-powershell#upgrading-existing-windows-powershell)
-   if needed. If you're on Windows 10, you already have PowerShell 5.1 installed.
+   [Windows PowerShell 5.1](/powershell/scripting/install/installing-windows-powershell#upgrading-existing-windows-powershell).
+   If you're on Windows 10 version 1607 or higher, you already have PowerShell 5.1 installed.
 2. Install [.NET Framework 4.7.2 or later](/dotnet/framework/install).
 3. Make sure you have the latest version of PowerShellGet. Run `Install-Module -Name PowerShellGet -Force`.
 
 ## Install the Azure PowerShell module
 
-Using the PowerShellGet cmdlets is the preferred installation method. This method works the same on
+> [!WARNING]
+> We do not support having both the AzureRM and Az modules installed for PowerShell 5.1 on Windows
+> at the same time. If you need to keep AzureRM available on your system, install the Az module for
+> PowerShell 7.x or later.
+
+Using the PowerShellGet cmdlets is the preferred installation method. Install the Az module for the
+current user only. This is the recommended installation scope. This method works the same on
 Windows, macOS, and Linux platforms. Run the following command from a PowerShell session:
 
 ```powershell-interactive
-Install-Module -Name Az -AllowClobber
+if (Get-Module -Name AzureRM -ListAvailable) {
+    Write-Warning -Message 'Az module not installed. Having both the AzureRM and Az modules installed at the same time is not supported.'
+} else {
+    Install-Module -Name Az -AllowClobber -Scope CurrentUser
+}
 ```
 
 By default, the PowerShell gallery isn't configured as a trusted repository for PowerShellGet. The
@@ -60,39 +71,30 @@ Are you sure you want to install the modules from 'PSGallery'?
 
 Answer `Yes` or `Yes to All` to continue with the installation.
 
-The Az module is a rollup module for the Azure PowerShell cmdlets. Installing it downloads all of
-the available Azure Resource Manager modules, and makes their cmdlets available for use.
-
-> [!WARNING]
-> We do not support having both the AzureRM and Az modules installed for PowerShell 5.1 for Windows
-> at the same time. If you need to keep AzureRM available on your system, install the Az module for
-> PowerShell Core 6.x or later.
-
-First, [install PowerShell Core 6.x or later](/powershell/scripting/install/installing-powershell-core-on-windows)
-
-Then, from a PowerShell Core session, install the Az module for the current user only. This is the
-recommended installation scope.
-
-```powershell-interactive
-Install-Module -Name Az -AllowClobber -Scope CurrentUser
-```
-
 Installing the module for all users on a system requires elevated privileges. Start the PowerShell
 session using **Run as administrator** in Windows or use the `sudo` command on macOS or Linux:
 
 ```powershell-interactive
-Install-Module -Name Az -AllowClobber -Scope AllUsers
+if (Get-Module -Name AzureRM -ListAvailable) {
+    Write-Warning -Message 'Az module not installed. Having both the AzureRM and Az modules installed at the same time is not supported.'
+} else {
+    Install-Module -Name Az -AllowClobber -Scope AllUsers
+}
 ```
+
+The Az module is a rollup module for the Azure PowerShell cmdlets. Installing it downloads all of
+the available Az PowerShell modules, and makes their cmdlets available for use.
 
 ## Install offline
 
-In some environments it's not possible to connect to the PowerShell Gallery. In those situations,
+In some environments, it's not possible to connect to the PowerShell Gallery. In those situations,
 you can still install offline using one of these methods:
 
 * Download the modules to another location in your network and use that as an installation source.
-  This allows you to cache PowerShell modules on a single server or file share to be deployed with
-  PowerShellGet to any disconnected systems. Learn how to set up a local repository and install on
-  disconnected systems with [Working with local PowerShellGet repositories](/powershell/scripting/gallery/how-to/working-with-local-psrepositories).
+  This method allows you to cache PowerShell modules on a single server or file share to be deployed
+  with PowerShellGet to any disconnected systems. Learn how to set up a local repository and install
+  on disconnected systems with
+  [Working with local PowerShellGet repositories](/powershell/scripting/gallery/how-to/working-with-local-psrepositories).
 * [Download the Azure PowerShell MSI](install-az-ps-msi.md) to a machine connected to the network,
   and then copy the installer to systems without access to PowerShell Gallery. Keep in mind that the
   MSI installer only works for PowerShell 5.1 on Windows.
@@ -106,8 +108,7 @@ you can still install offline using one of these methods:
 ## Troubleshooting
 
 Here are some common problems seen when installing the Azure PowerShell module. If you experience a
-problem not listed here, please
-[file an issue on GitHub](https://github.com/azure/azure-powershell/issues).
+problem not listed here, [file an issue on GitHub](https://github.com/azure/azure-powershell/issues).
 
 ### Proxy blocks connection
 
@@ -146,7 +147,7 @@ Connect-AzAccount
 > of the way the module is structured, this can take a few seconds.
 
 You'll need to repeat these steps for every new PowerShell session you start. To learn how to
-persist your Azure sign-in across PowerShell sessions, see
+persist your Azure sign in across PowerShell sessions, see
 [Persist user credentials across PowerShell sessions](context-persistence.md).
 
 ## Update the Azure PowerShell module
@@ -158,7 +159,7 @@ originally used the MSI package then you should download and install the new MSI
 
 The PowerShellGet cmdlets cannot update modules that were installed from an MSI package. MSI
 packages do not update modules that were installed using PowerShellGet. If you have any issues
-updating using PowershellGet then you should **reinstall**, rather than **update**. Reinstalling is
+updating using PowershellGet, then you should **reinstall**, rather than **update**. Reinstalling is
 done the same way as installing, but you need to add the `-Force` parameter:
 
 ```powershell
@@ -176,7 +177,7 @@ It's possible to install more than one version of Azure PowerShell. To check if 
 versions of Azure PowerShell installed, use the following command:
 
 ```powershell-interactive
-Get-InstalledModule -Name Az -AllVersions | select Name,Version
+Get-InstalledModule -Name Az -AllVersions | Select-Object -Property Name, Version
 ```
 
 To remove a version of Azure PowerShell, see [Uninstall the Azure PowerShell module](uninstall-az-ps.md).

--- a/docs-conceptual/azps-3.8.0/install-az-ps.md
+++ b/docs-conceptual/azps-3.8.0/install-az-ps.md
@@ -3,7 +3,7 @@ title: Install Azure PowerShell with PowerShellGet
 description: How to install Azure PowerShell with PowerShellGet
 ms.devlang: powershell
 ms.topic: conceptual
-ms.date: 02/26/2020
+ms.date: 05/14/2020
 ---
 
 # Install Azure PowerShell
@@ -17,10 +17,14 @@ preinstalled in [Docker images](azureps-in-docker.md).
 
 ## Requirements
 
-Azure PowerShell works with PowerShell 7.x and later on all platforms. It is also supported with
+> [!NOTE]
+> PowerShell 7.x and later is the recommended version of PowerShell for use with Azure PowerShell on
+> all platforms.
+
+Azure PowerShell works with PowerShell 6.2.4 and later on all platforms. It is also supported with
 PowerShell 5.1 on Windows. Install the
 [latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
-your operating system. Azure PowerShell has no additional requirements when run on PowerShell 7.x
+your operating system. Azure PowerShell has no additional requirements when run on PowerShell 6.2.4
 and later.
 
 To check your PowerShell version, run the command:
@@ -42,7 +46,7 @@ To use Azure PowerShell in PowerShell 5.1 on Windows:
 > [!WARNING]
 > We do not support having both the AzureRM and Az modules installed for PowerShell 5.1 on Windows
 > at the same time. If you need to keep AzureRM available on your system, install the Az module for
-> PowerShell 7.x or later.
+> PowerShell 6.2.4 or later.
 
 Using the PowerShellGet cmdlets is the preferred installation method. Install the Az module for the
 current user only. This is the recommended installation scope. This method works the same on
@@ -56,8 +60,8 @@ if (Get-Module -Name AzureRM -ListAvailable) {
 }
 ```
 
-By default, the PowerShell gallery isn't configured as a trusted repository for PowerShellGet. The
-first time you use the PSGallery you see the following prompt:
+By default, the PowerShell gallery isn't configured as a trusted repository for PowerShellGet and
+you see the following prompt:
 
 ```Output
 Untrusted repository
@@ -143,8 +147,8 @@ Connect-AzAccount
 ```
 
 > [!NOTE]
-> If you've disabled module autoloading, manually import the module with `Import-Module Az`. Because
-> of the way the module is structured, this can take a few seconds.
+> If you've disabled module autoloading, manually import the module with `Import-Module -Name Az`.
+> Because of the way the module is structured, this can take a few seconds.
 
 You'll need to repeat these steps for every new PowerShell session you start. To learn how to
 persist your Azure sign in across PowerShell sessions, see
@@ -163,7 +167,11 @@ updating using PowershellGet, then you should **reinstall**, rather than **updat
 done the same way as installing, but you need to add the `-Force` parameter:
 
 ```powershell
-Install-Module -Name Az -AllowClobber -Force
+if (Get-Module -Name AzureRM -ListAvailable) {
+    Write-Warning -Message 'Az module not installed. Having both the AzureRM and Az modules installed at the same time is not supported.'
+} else {
+    Install-Module -Name Az -AllowClobber -Force
+}
 ```
 
 Unlike MSI-based installations, installing or updating using PowerShellGet does not remove older
@@ -182,7 +190,7 @@ Get-InstalledModule -Name Az -AllVersions | Select-Object -Property Name, Versio
 
 To remove a version of Azure PowerShell, see [Uninstall the Azure PowerShell module](uninstall-az-ps.md).
 
-If you have more than one version of the module installed, module autoload and `Import-Module` load
+If you have more than one version of the module installed, module autoload, and `Import-Module` load
 the latest version by default.
 
 You can install or load a specific version of the `Az` module by using the `-RequiredVersion`


### PR DESCRIPTION
Fixes #1385
Moved message about not supporting AzureRM and Az at the same time prior to installation.
Added logic to the install commands to prevent the Az module from being installed if AzureRM exists.