### PR TITLE
updated add subscription to Azure AD tenant link

### DIFF
--- a/docs-conceptual/azps-4.1.0/manage-subscriptions-azureps.md
+++ b/docs-conceptual/azps-4.1.0/manage-subscriptions-azureps.md
@@ -24,7 +24,7 @@ is associated with a subscription.
 To learn more about the differences between tenants, users, and subscriptions, see the
 [Azure cloud terminology dictionary](/azure/azure-glossary-cloud-terminology).  To learn how to add a new subscription to your Azure Active
 Directory tenant, see
-[How to add an Azure subscription to Azure Active Directory](/azure/active-directory/active-directory-how-subscriptions-associated-directory).
+[Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory).
 To learn how to sign in to a specific tenant, see [Sign in with Azure PowerShell](/powershell/azure/authenticate-azureps).
 
 ## Change the active subscription


### PR DESCRIPTION
The link used the old title of the article, so I updated it so that it would match the new title. This is to make sure the customer doesn't get confused and think they are on the wrong article, contributing to a high bounce rate.