### PR TITLE
update latest VMAccessAgent version to 2.4 instead of 2.0

### DIFF
--- a/azurermps-6.13.0/AzureRM.Compute/Set-AzureRmVMAccessExtension.md
+++ b/azurermps-6.13.0/AzureRM.Compute/Set-AzureRmVMAccessExtension.md
@@ -28,7 +28,7 @@ The **Set-AzureRmVMAccessExtension** cmdlet adds the Virtual Machine Access (VMA
 
 ### Example 1: Add a VMAccess extension
 ```
-PS C:\> Set-AzureRmVMAccessExtension -ResourceGroupName "ResrouceGroup11" -Location "Central US" -VMName "VirtualMachine07" -Name "ContosoTest" -TypeHandlerVersion "2.0" -UserName "PFuller" -Password "Password"
+PS C:\> Set-AzureRmVMAccessExtension -ResourceGroupName "ResrouceGroup11" -Location "Central US" -VMName "VirtualMachine07" -Name "ContosoTest" -TypeHandlerVersion "2.4" -UserName "PFuller" -Password "Password"
 ```
 
 This command adds a VMAccess extension for the virtual machine named VirtualMachine07 in ResrouceGroup11.


### PR DESCRIPTION
same as https://github.com/Azure/azure-powershell/pull/10755 - but for **_Set-AzureRmVMAccessExtension_**


version 2.0 is pretty old and users should use 2.4 instead
so I'm modifying the sample here to ensure they're using latest version.