### PR TITLE
Fixing repo issues from Switch azure-docs-powershell to SDP pipeline …

### DIFF
--- a/azps-0.10.0/Az.Compute/New-AzVMSqlServerAutoBackupConfig.md
+++ b/azps-0.10.0/Az.Compute/New-AzVMSqlServerAutoBackupConfig.md
@@ -330,7 +330,7 @@ This cmdlet does not accept any input.
 
 ## RELATED LINKS
 
-[New-AzureVMSqlServerAutoPatchingConfig](./New-AzureVMSqlServerAutoPatchingConfig.md)
+
 
 [Set-AzVMSqlServerExtension](./Set-AzVMSqlServerExtension.md)
 

--- a/azps-0.10.0/Az.Compute/New-AzVMSqlServerAutoPatchingConfig.md
+++ b/azps-0.10.0/Az.Compute/New-AzVMSqlServerAutoPatchingConfig.md
@@ -154,7 +154,7 @@ This cmdlet returns object contains settings for automated patching.
 
 ## RELATED LINKS
 
-[New-AzureVMSqlServerAutoBackupConfig](./New-AzureVMSqlServerAutoBackupConfig.md)
+
 
 [Set-AzVMSqlServerExtension](./Set-AzVMSqlServerExtension.md)
 

--- a/azps-0.10.0/Az.Compute/Set-AzVMSqlServerExtension.md
+++ b/azps-0.10.0/Az.Compute/Set-AzVMSqlServerExtension.md
@@ -229,9 +229,9 @@ This cmdlet does not accept any input.
 
 [Get-AzVMSqlServerExtension](./Get-AzVMSqlServerExtension.md)
 
-[New-AzureVMSqlServerAutoPatchingConfig](./New-AzureVMSqlServerAutoPatchingConfig.md)
 
-[New-AzureVMSqlServerAutoBackupConfig](./New-AzureVMSqlServerAutoBackupConfig.md)
+
+
 
 [Remove-AzVMSqlServerExtension](./Remove-AzVMSqlServerExtension.md)
 

--- a/azps-0.10.0/Az.KeyVault/Get-AzKeyVaultCertificate.md
+++ b/azps-0.10.0/Az.KeyVault/Get-AzKeyVaultCertificate.md
@@ -218,4 +218,4 @@ This cmdlet does not accept any input.
 
 [Remove-AzKeyVaultCertificate](./Remove-AzKeyVaultCertificate.md)
 
-[Undo-AzKeyVaultSecretCertificate](./Undo-AzKeyVaultSecretCertificate.md)
+

--- a/azps-0.10.0/Az.KeyVault/Undo-AzKeyVaultSecretRemoval.md
+++ b/azps-0.10.0/Az.KeyVault/Undo-AzKeyVaultSecretRemoval.md
@@ -130,6 +130,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultSecret](./Remove-AzKeyVaultSecret.md)
 
-[Add-AzKeyVaultSecret](./Add-AzKeyVaultSecret.md)
+
 
 [Get-AzKeyVaultSecret](./Get-AzKeyVaultSecret.md)

--- a/azps-0.10.0/Az.Monitor/Get-AzActivityLogAlert.md
+++ b/azps-0.10.0/Az.Monitor/Get-AzActivityLogAlert.md
@@ -130,7 +130,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Set-AzActivityLogAlert](./Set-AzActivityLogAlert.md)
 
-[Update-AzActivityLogAlert](./Update-AzActivityLogAlert.md)
+
 
 [Remove-AzActivityLogAlert](./Remove-AzActivityLogAlert.md)
 

--- a/azps-0.10.0/Az.Monitor/Get-AzAlertHistory.md
+++ b/azps-0.10.0/Az.Monitor/Get-AzAlertHistory.md
@@ -393,7 +393,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-0.10.0/Az.Monitor/Get-AzAlertRule.md
+++ b/azps-0.10.0/Az.Monitor/Get-AzAlertRule.md
@@ -156,7 +156,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-0.10.0/Az.Monitor/New-AzAlertRuleEmail.md
+++ b/azps-0.10.0/Az.Monitor/New-AzAlertRuleEmail.md
@@ -110,7 +110,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-0.10.0/Az.Monitor/New-AzAlertRuleWebhook.md
+++ b/azps-0.10.0/Az.Monitor/New-AzAlertRuleWebhook.md
@@ -103,7 +103,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-0.10.0/Az.Network/Add-AzRouteFilterRuleConfig.md
+++ b/azps-0.10.0/Az.Network/Add-AzRouteFilterRuleConfig.md
@@ -195,11 +195,11 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzRouteFilter](./Get-AzRouteFilter.md)
 
-[New-AzRouteFilterRuleConfigConfig](./New-AzRouteFilterRuleConfigConfig.md)
 
-[Remove-AzRouteFilterRuleConfigConfig](./Remove-AzRouteFilterRuleConfigConfig.md)
 
-[Set-AzRouteFilterRuleConfigConfig](./Set-AzRouteFilterRuleConfigConfig.md)
+
+
+
 
 [Set-AzRouteFilter](./Set-AzRouteFilter.md)
 

--- a/azps-0.10.0/Az.Resources/Export-AzResourceGroup.md
+++ b/azps-0.10.0/Az.Resources/Export-AzResourceGroup.md
@@ -240,6 +240,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResourceGroup](./Find-AzResourceGroup.md)
+
 
 

--- a/azps-0.10.0/Az.Resources/Get-AzADApplication.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADApplication.md
@@ -252,7 +252,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzADApplication](./Remove-AzADApplication.md)
 
-[Set-AzADApplication](./Set-AzADApplication.md)
-
 [New-AzADApplication](./New-AzADApplication.md)
 

--- a/azps-0.10.0/Az.Resources/Get-AzADServicePrincipal.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADServicePrincipal.md
@@ -276,8 +276,6 @@ Parameters: ApplicationObject (ByValue)
 
 [New-AzADServicePrincipal](./New-AzADServicePrincipal.md)
 
-[Set-AzADServicePrincipal](./Set-AzADServicePrincipal.md)
-
 [Remove-AzADServicePrincipal](./Remove-AzADServicePrincipal.md)
 
 [Get-AzADApplication](./Get-AzADApplication.md)

--- a/azps-0.10.0/Az.Resources/Get-AzADUser.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADUser.md
@@ -256,7 +256,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzADUser](./New-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 
 [Remove-AzADUser](./Remove-AzADUser.md)
 

--- a/azps-0.10.0/Az.Resources/Get-AzResource.md
+++ b/azps-0.10.0/Az.Resources/Get-AzResource.md
@@ -344,7 +344,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Move-AzResource](./Move-AzResource.md)
 

--- a/azps-0.10.0/Az.Resources/Move-AzResource.md
+++ b/azps-0.10.0/Az.Resources/Move-AzResource.md
@@ -225,7 +225,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-0.10.0/Az.Resources/New-AzADUser.md
+++ b/azps-0.10.0/Az.Resources/New-AzADUser.md
@@ -199,6 +199,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzADUser](./Get-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 
 [Remove-AzADUser](./Remove-AzADUser.md)

--- a/azps-0.10.0/Az.Resources/New-AzResource.md
+++ b/azps-0.10.0/Az.Resources/New-AzResource.md
@@ -431,7 +431,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-0.10.0/Az.Resources/Remove-AzADApplication.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADApplication.md
@@ -231,7 +231,5 @@ Keywords: azure, Az, arm, resource, management, manager, resource, group, templa
 
 [Get-AzADApplication](./Get-AzADApplication.md)
 
-[Set-AzADApplication](./Set-AzADApplication.md)
-
 [Remove-AzADAppCredential](./Remove-AzADAppCredential.md)
 

--- a/azps-0.10.0/Az.Resources/Remove-AzADServicePrincipal.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADServicePrincipal.md
@@ -292,8 +292,6 @@ Keywords: azure, Az, arm, resource, management, manager, resource, group, templa
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
 
-[Set-AzADServicePrincipal](./Set-AzADServicePrincipal.md)
-
 [Remove-AzADApplication](./Remove-AzADApplication.md)
 
 [Remove-AzADAppCredential](./Remove-AzADAppCredential.md)

--- a/azps-0.10.0/Az.Resources/Remove-AzADUser.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADUser.md
@@ -251,5 +251,5 @@ Parameters: InputObject (ByValue)
 
 [Get-AzADUser](./Get-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 

--- a/azps-0.10.0/Az.Resources/Remove-AzResource.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzResource.md
@@ -307,7 +307,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-0.10.0/Az.Resources/Set-AzResource.md
+++ b/azps-0.10.0/Az.Resources/Set-AzResource.md
@@ -460,7 +460,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-1.8.0/Az.ApiManagement/Add-AzApiManagementRegion.md
+++ b/azps-1.8.0/Az.ApiManagement/Add-AzApiManagementRegion.md
@@ -161,6 +161,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Update-AzApiManagementRegion](./Update-AzApiManagementRegion.md)
 
-[Update-AzApiManagementDeployment](./Update-AzApiManagementDeployment.md)
+
 
 

--- a/azps-1.8.0/Az.ApiManagement/Get-AzApiManagementApiRelease.md
+++ b/azps-1.8.0/Az.ApiManagement/Get-AzApiManagementApiRelease.md
@@ -143,4 +143,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzApiManagementApiRelease](./Remove-AzApiManagementApiRelease.md)
 
-[Set-AzApiManagementApiRelease](./Set-AzApiManagementApiRelease.md)

--- a/azps-1.8.0/Az.ApiManagement/New-AzApiManagementApiRelease.md
+++ b/azps-1.8.0/Az.ApiManagement/New-AzApiManagementApiRelease.md
@@ -192,4 +192,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzApiManagementApiRelease](./Remove-AzApiManagementApiRelease.md)
 
-[Set-AzApiManagementApiRelease](./Set-AzApiManagementApiRelease.md)

--- a/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackend.md
+++ b/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackend.md
@@ -305,7 +305,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackendCredential](./New-AzApiManagementBackendCredential.md)
 

--- a/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackendCredential.md
+++ b/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackendCredential.md
@@ -147,7 +147,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackendProxy.md
+++ b/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackendProxy.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackendServiceFabric.md
+++ b/azps-1.8.0/Az.ApiManagement/New-AzApiManagementBackendServiceFabric.md
@@ -150,7 +150,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-1.8.0/Az.ApiManagement/New-AzApiManagementVirtualNetwork.md
+++ b/azps-1.8.0/Az.ApiManagement/New-AzApiManagementVirtualNetwork.md
@@ -94,5 +94,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Update-AzApiManagementDeployment](./Update-AzApiManagementDeployment.md)
+
 

--- a/azps-1.8.0/Az.ApiManagement/Remove-AzApiManagementApiRelease.md
+++ b/azps-1.8.0/Az.ApiManagement/Remove-AzApiManagementApiRelease.md
@@ -190,4 +190,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzApiManagementApiRelease](./New-AzApiManagementApiRelease.md)
 
-[Set-AzApiManagementApiRelease](./Set-AzApiManagementApiRelease.md)

--- a/azps-1.8.0/Az.ApiManagement/Remove-AzApiManagementBackend.md
+++ b/azps-1.8.0/Az.ApiManagement/Remove-AzApiManagementBackend.md
@@ -145,7 +145,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-1.8.0/Az.ApiManagement/Set-AzApiManagementBackend.md
+++ b/azps-1.8.0/Az.ApiManagement/Set-AzApiManagementBackend.md
@@ -316,7 +316,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-1.8.0/Az.ApiManagement/Update-AzApiManagementRegion.md
+++ b/azps-1.8.0/Az.ApiManagement/Update-AzApiManagementRegion.md
@@ -167,4 +167,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzApiManagementRegion](./Remove-AzApiManagementRegion.md)
 
-[Update-AzApiManagementDeployment](./Update-AzApiManagementDeployment.md)
+

--- a/azps-1.8.0/Az.Batch/Disable-AzBatchComputeNodeScheduling.md
+++ b/azps-1.8.0/Az.Batch/Disable-AzBatchComputeNodeScheduling.md
@@ -195,7 +195,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Enable-AzBatchComputeNodeScheduling](./Enable-AzBatchComputeNodeScheduling.md)
 

--- a/azps-1.8.0/Az.Batch/Disable-AzBatchJob.md
+++ b/azps-1.8.0/Az.Batch/Disable-AzBatchJob.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/Disable-AzBatchJobSchedule.md
+++ b/azps-1.8.0/Az.Batch/Disable-AzBatchJobSchedule.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-1.8.0/Az.Batch/Enable-AzBatchJobSchedule.md
+++ b/azps-1.8.0/Az.Batch/Enable-AzBatchJobSchedule.md
@@ -101,7 +101,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Disable-AzBatchJobSchedule](./Disable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-1.8.0/Az.Batch/Enable-AzBatchTask.md
+++ b/azps-1.8.0/Az.Batch/Enable-AzBatchTask.md
@@ -178,7 +178,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchTask](./Get-AzBatchTask.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchCertificate.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchCertificate.md
@@ -233,7 +233,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchCertificate](./New-AzBatchCertificate.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchJob.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchJob.md
@@ -295,7 +295,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchJobSchedule.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchJobSchedule.md
@@ -231,7 +231,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchJobSchedule](./New-AzBatchJobSchedule.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchJobStatistic.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchJobStatistic.md
@@ -98,10 +98,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPoolStatistic](./Get-AzBatchPoolStatistic.md)
 
-[Get-AzBatchPoolUsageMetrics](./Get-AzBatchPoolUsageMetrics.md)
+
 
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchNodeAgentSku.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchNodeAgentSku.md
@@ -122,6 +122,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchNodeFile.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchNodeFile.md
@@ -352,7 +352,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchNodeFileContent.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchNodeFileContent.md
@@ -323,7 +323,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchNodeFile](./Get-AzBatchNodeFile.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchPool.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchPool.md
@@ -234,7 +234,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchPool](./New-AzBatchPool.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchPoolStatistic.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchPoolStatistic.md
@@ -99,9 +99,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
 
-[Get-AzBatchPoolUsageMetrics](./Get-AzBatchPoolUsageMetrics.md)
+
+
 
 [Get-AzBatchJobStatistic](./Get-AzBatchJobStatistic.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchPoolUsageMetric.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchPoolUsageMetric.md
@@ -185,10 +185,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
 
-[Get-AzBatchPoolStatistics](./Get-AzBatchPoolStatistics.md)
 
-[Get-AzBatchJobStatistics](./Get-AzBatchJobStatistics.md)
+
+
+
 
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchRemoteDesktopProtocolFile.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchRemoteDesktopProtocolFile.md
@@ -201,7 +201,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchRemoteLoginSetting.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchRemoteLoginSetting.md
@@ -158,7 +158,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchTask.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchTask.md
@@ -277,7 +277,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/Get-AzBatchTaskCount.md
+++ b/azps-1.8.0/Az.Batch/Get-AzBatchTaskCount.md
@@ -133,7 +133,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchAccountKey.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchAccountKey.md
@@ -128,7 +128,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Azure Batch Cmdlets](./Az.Batch.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchCertificate.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchCertificate.md
@@ -147,7 +147,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchCertificate](./Get-AzBatchCertificate.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Remove-AzBatchCertificate](./Remove-AzBatchCertificate.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchComputeNodeUser.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchComputeNodeUser.md
@@ -208,7 +208,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchJob.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchJob.md
@@ -304,7 +304,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchJobSchedule.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchJobSchedule.md
@@ -177,7 +177,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchPool.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchPool.md
@@ -505,7 +505,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-1.8.0/Az.Batch/New-AzBatchTask.md
+++ b/azps-1.8.0/Az.Batch/New-AzBatchTask.md
@@ -464,7 +464,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchCertificate.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchCertificate.md
@@ -158,7 +158,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchCertificate](./Get-AzBatchCertificate.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchCertificate](./New-AzBatchCertificate.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchComputeNode.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchComputeNode.md
@@ -239,7 +239,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchComputeNodeUser.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchComputeNodeUser.md
@@ -165,7 +165,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzBatchComputeNodeUser](./New-AzBatchComputeNodeUser.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Azure Batch Cmdlets](./Az.Batch.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchJob.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchJob.md
@@ -163,7 +163,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchJob](./New-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchNodeFile.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchNodeFile.md
@@ -272,7 +272,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchNodeFile](./Get-AzBatchNodeFile.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchPool.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchPool.md
@@ -154,7 +154,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-1.8.0/Az.Batch/Remove-AzBatchTask.md
+++ b/azps-1.8.0/Az.Batch/Remove-AzBatchTask.md
@@ -198,7 +198,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchTask](./Get-AzBatchTask.md)
 

--- a/azps-1.8.0/Az.Batch/Set-AzBatchComputeNodeUser.md
+++ b/azps-1.8.0/Az.Batch/Set-AzBatchComputeNodeUser.md
@@ -157,7 +157,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchComputeNodeUser](./New-AzBatchComputeNodeUser.md)
 

--- a/azps-1.8.0/Az.Batch/Set-AzBatchJob.md
+++ b/azps-1.8.0/Az.Batch/Set-AzBatchJob.md
@@ -109,7 +109,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchJob](./New-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/Set-AzBatchPool.md
+++ b/azps-1.8.0/Az.Batch/Set-AzBatchPool.md
@@ -107,7 +107,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchPool](./New-AzBatchPool.md)
 

--- a/azps-1.8.0/Az.Batch/Set-AzBatchPoolOSVersion.md
+++ b/azps-1.8.0/Az.Batch/Set-AzBatchPoolOSVersion.md
@@ -113,6 +113,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 

--- a/azps-1.8.0/Az.Batch/Set-AzBatchTask.md
+++ b/azps-1.8.0/Az.Batch/Set-AzBatchTask.md
@@ -106,7 +106,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchTask](./Get-AzBatchTask.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchTask](./New-AzBatchTask.md)
 

--- a/azps-1.8.0/Az.Batch/Start-AzBatchPoolResize.md
+++ b/azps-1.8.0/Az.Batch/Start-AzBatchPoolResize.md
@@ -176,7 +176,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-1.8.0/Az.Batch/Stop-AzBatchCertificateDeletion.md
+++ b/azps-1.8.0/Az.Batch/Stop-AzBatchCertificateDeletion.md
@@ -115,7 +115,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Remove-AzBatchCertificate](./Remove-AzBatchCertificate.md)
 

--- a/azps-1.8.0/Az.Batch/Stop-AzBatchJob.md
+++ b/azps-1.8.0/Az.Batch/Stop-AzBatchJob.md
@@ -120,7 +120,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-1.8.0/Az.Batch/Stop-AzBatchJobSchedule.md
+++ b/azps-1.8.0/Az.Batch/Stop-AzBatchJobSchedule.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-1.8.0/Az.Batch/Stop-AzBatchPoolResize.md
+++ b/azps-1.8.0/Az.Batch/Stop-AzBatchPoolResize.md
@@ -108,7 +108,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-1.8.0/Az.Batch/Test-AzBatchAutoScale.md
+++ b/azps-1.8.0/Az.Batch/Test-AzBatchAutoScale.md
@@ -121,7 +121,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchAutoScale](./Enable-AzBatchAutoScale.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Azure Batch Cmdlets](./Az.Batch.md)
 

--- a/azps-1.8.0/Az.Compute/Get-AzVMBootDiagnosticsData.md
+++ b/azps-1.8.0/Az.Compute/Get-AzVMBootDiagnosticsData.md
@@ -162,6 +162,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-AzVMBootDiagnostics](./Set-AzVMBootDiagnostics.md)
+
 
 

--- a/azps-1.8.0/Az.FrontDoor/Get-AzFrontDoorFireWallPolicy.md
+++ b/azps-1.8.0/Az.FrontDoor/Get-AzFrontDoorFireWallPolicy.md
@@ -111,5 +111,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzFrontDoorFireWallPolicy](./New-AzFrontDoorFireWallPolicy.md)
-[Set-AzFrontDoorFireWallPolicy](./Set-AzFrontDoorFireWallPolicy.md)
+
 [Remove-AzFrontDoorFireWallPolicy](./Remove-AzFrontDoorFireWallPolicy.md)

--- a/azps-1.8.0/Az.FrontDoor/New-AzFrontDoorCustomRuleObject.md
+++ b/azps-1.8.0/Az.FrontDoor/New-AzFrontDoorCustomRuleObject.md
@@ -179,4 +179,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzFrontDoorFireWallPolicy](./New-AzFrontDoorFireWallPolicy.md)
-[Set-AzFrontDoorFireWallPolicy](./Set-AzFrontDoorFireWallPolicy.md)
+

--- a/azps-1.8.0/Az.FrontDoor/New-AzFrontDoorFireWallPolicy.md
+++ b/azps-1.8.0/Az.FrontDoor/New-AzFrontDoorFireWallPolicy.md
@@ -239,7 +239,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-AzFrontDoorFireWallPolicy](./Set-AzFrontDoorFireWallPolicy.md)
+
 [Get-AzFrontDoorFireWallPolicy](./Get-AzFrontDoorFireWallPolicy.md)
 [Remove-AzFrontDoorFireWallPolicy](./Remove-AzFrontDoorFireWallPolicy.md)
 [New-AzFrontDoorManagedRuleObject](./New-AzFrontDoorManagedRuleObject.md)

--- a/azps-1.8.0/Az.FrontDoor/New-AzFrontDoorManagedRuleObject.md
+++ b/azps-1.8.0/Az.FrontDoor/New-AzFrontDoorManagedRuleObject.md
@@ -121,5 +121,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzFrontDoorFireWallPolicy](./New-AzFrontDoorFireWallPolicy.md)
-[Set-AzFrontDoorFireWallPolicy](./Set-AzFrontDoorFireWallPolicy.md)
+
 [New-AzFrontDoorRuleGroupOverrideObject](./New-AzFrontDoorRuleGroupOverrideObject.md)

--- a/azps-1.8.0/Az.KeyVault/Add-AzKeyVaultKey.md
+++ b/azps-1.8.0/Az.KeyVault/Add-AzKeyVaultKey.md
@@ -556,4 +556,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultKey](./Remove-AzKeyVaultKey.md)
 
-[Set-AzKeyVaultKeyAttribute](./Set-AzKeyVaultKeyAttribute.md)
+

--- a/azps-1.8.0/Az.KeyVault/Get-AzKeyVaultCertificate.md
+++ b/azps-1.8.0/Az.KeyVault/Get-AzKeyVaultCertificate.md
@@ -387,4 +387,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultCertificate](./Remove-AzKeyVaultCertificate.md)
 
-[Undo-AzKeyVaultSecretCertificate](./Undo-AzKeyVaultSecretCertificate.md)
+

--- a/azps-1.8.0/Az.KeyVault/Get-AzKeyVaultKey.md
+++ b/azps-1.8.0/Az.KeyVault/Get-AzKeyVaultKey.md
@@ -416,5 +416,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Undo-AzKeyVaultKeyRemoval](./Undo-AzKeyVaultKeyRemoval.md)
 
-[Set-AzKeyVaultKeyAttribute](./Set-AzKeyVaultKeyAttribute.md)
+
 

--- a/azps-1.8.0/Az.KeyVault/Remove-AzKeyVaultKey.md
+++ b/azps-1.8.0/Az.KeyVault/Remove-AzKeyVaultKey.md
@@ -240,7 +240,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzKeyVaultKey](./Get-AzKeyVaultKey.md)
 
-[Set-AzKeyVaultKeyAttribute](./Set-AzKeyVaultKeyAttribute.md)
+
 
 [Undo-AzKeyVaultKeyRemoval](./Undo-AzKeyVaultKeyRemoval.md)
 

--- a/azps-1.8.0/Az.KeyVault/Undo-AzKeyVaultSecretRemoval.md
+++ b/azps-1.8.0/Az.KeyVault/Undo-AzKeyVaultSecretRemoval.md
@@ -164,6 +164,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultSecret](./Remove-AzKeyVaultSecret.md)
 
-[Add-AzKeyVaultSecret](./Add-AzKeyVaultSecret.md)
+
 
 [Get-AzKeyVaultSecret](./Get-AzKeyVaultSecret.md)

--- a/azps-1.8.0/Az.Media/New-AzMediaServiceStorageConfig.md
+++ b/azps-1.8.0/Az.Media/New-AzMediaServiceStorageConfig.md
@@ -130,6 +130,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Sync-AzMediaServiceStorageKeys](./Sync-AzMediaServiceStorageKeys.md)
+
 
 

--- a/azps-1.8.0/Az.Media/Set-AzMediaServiceKey.md
+++ b/azps-1.8.0/Az.Media/Set-AzMediaServiceKey.md
@@ -149,6 +149,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzMediaServiceKeys](./Get-AzMediaServiceKeys.md)
+
 
 

--- a/azps-1.8.0/Az.Monitor/Get-AzActivityLogAlert.md
+++ b/azps-1.8.0/Az.Monitor/Get-AzActivityLogAlert.md
@@ -130,7 +130,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Set-AzActivityLogAlert](./Set-AzActivityLogAlert.md)
 
-[Update-AzActivityLogAlert](./Update-AzActivityLogAlert.md)
+
 
 [Remove-AzActivityLogAlert](./Remove-AzActivityLogAlert.md)
 

--- a/azps-1.8.0/Az.Monitor/Get-AzAlertHistory.md
+++ b/azps-1.8.0/Az.Monitor/Get-AzAlertHistory.md
@@ -393,7 +393,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-1.8.0/Az.Monitor/Get-AzAlertRule.md
+++ b/azps-1.8.0/Az.Monitor/Get-AzAlertRule.md
@@ -156,7 +156,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-1.8.0/Az.Monitor/New-AzAlertRuleEmail.md
+++ b/azps-1.8.0/Az.Monitor/New-AzAlertRuleEmail.md
@@ -110,7 +110,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-1.8.0/Az.Monitor/New-AzAlertRuleWebhook.md
+++ b/azps-1.8.0/Az.Monitor/New-AzAlertRuleWebhook.md
@@ -103,7 +103,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-1.8.0/Az.Network/Get-AzApplicationGatewayConnectionDraining.md
+++ b/azps-1.8.0/Az.Network/Get-AzApplicationGatewayConnectionDraining.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzApplicationGateway](./Get-AzApplicationGateway.md)
 
-[Get-AzApplicationGatewayBackendHttpSettings](./Get-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [New-AzApplicationGatewayConnectionDraining](./New-AzApplicationGatewayConnectionDraining.md)
 

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcher.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcher.md
@@ -193,6 +193,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherFlowLogStatus.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherFlowLogStatus.md
@@ -269,6 +269,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherNextHop.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherNextHop.md
@@ -277,6 +277,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherPacketCapture.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherPacketCapture.md
@@ -237,7 +237,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+
 

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherReachabilityProvidersList.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherReachabilityProvidersList.md
@@ -311,6 +311,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherReachabilityReport.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherReachabilityReport.md
@@ -360,6 +360,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherSecurityGroupView.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherSecurityGroupView.md
@@ -223,6 +223,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherTopology.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherTopology.md
@@ -298,7 +298,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+
 

--- a/azps-1.8.0/Az.Network/Get-AzNetworkWatcherTroubleshootingResult.md
+++ b/azps-1.8.0/Az.Network/Get-AzNetworkWatcherTroubleshootingResult.md
@@ -215,6 +215,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Get-AzVpnClientPackage.md
+++ b/azps-1.8.0/Az.Network/Get-AzVpnClientPackage.md
@@ -118,6 +118,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Resize-AzVirtualNetworkGateway](./Resize-AzVirtualNetworkGateway.md)
 
-[Set-AzVirtualNetworkGatewayVpnClientConfig](./Set-AzVirtualNetworkGatewayVpnClientConfig.md)
+
 
 

--- a/azps-1.8.0/Az.Network/Invoke-AzNetworkWatcherNetworkConfigurationDiagnostic.md
+++ b/azps-1.8.0/Az.Network/Invoke-AzNetworkWatcherNetworkConfigurationDiagnostic.md
@@ -308,6 +308,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/New-AzApplicationGateway.md
+++ b/azps-1.8.0/Az.Network/New-AzApplicationGateway.md
@@ -773,7 +773,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzApplicationGatewayBackendAddressPool](./New-AzApplicationGatewayBackendAddressPool.md)
 
-[New-AzApplicationGatewayBackendHttpSettings](./New-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [New-AzApplicationGatewayFrontendIPConfig](./New-AzApplicationGatewayFrontendIPConfig.md)
 

--- a/azps-1.8.0/Az.Network/New-AzApplicationGatewayPathRuleConfig.md
+++ b/azps-1.8.0/Az.Network/New-AzApplicationGatewayPathRuleConfig.md
@@ -271,7 +271,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzApplicationGatewayBackendAddressPool](./New-AzApplicationGatewayBackendAddressPool.md)
 
-[New-AzApplicationGatewayBackendHttpSettings](./New-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [New-AzApplicationGatewayPathRuleConfig](./New-AzApplicationGatewayPathRuleConfig.md)
 

--- a/azps-1.8.0/Az.Network/New-AzNetworkWatcher.md
+++ b/azps-1.8.0/Az.Network/New-AzNetworkWatcher.md
@@ -217,6 +217,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/New-AzNetworkWatcherNetworkConfigurationDiagnosticProfile.md
+++ b/azps-1.8.0/Az.Network/New-AzNetworkWatcherNetworkConfigurationDiagnosticProfile.md
@@ -225,6 +225,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/New-AzNetworkWatcherPacketCapture.md
+++ b/azps-1.8.0/Az.Network/New-AzNetworkWatcherPacketCapture.md
@@ -391,8 +391,8 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+
 
 

--- a/azps-1.8.0/Az.Network/New-AzNetworkWatcherProtocolConfiguration.md
+++ b/azps-1.8.0/Az.Network/New-AzNetworkWatcherProtocolConfiguration.md
@@ -205,6 +205,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/New-AzPacketCaptureFilterConfig.md
+++ b/azps-1.8.0/Az.Network/New-AzPacketCaptureFilterConfig.md
@@ -216,6 +216,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-1.8.0/Az.Network/Remove-AzApplicationGatewayConnectionDraining.md
+++ b/azps-1.8.0/Az.Network/Remove-AzApplicationGatewayConnectionDraining.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzApplicationGateway](./Get-AzApplicationGateway.md)
 
-[Get-AzApplicationGatewayBackendHttpSettings](./Get-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [Get-AzApplicationGatewayConnectionDraining](./Get-AzApplicationGatewayConnectionDraining.md)
 

--- a/azps-1.8.0/Az.Network/Remove-AzNetworkWatcher.md
+++ b/azps-1.8.0/Az.Network/Remove-AzNetworkWatcher.md
@@ -253,6 +253,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Remove-AzNetworkWatcherPacketCapture.md
+++ b/azps-1.8.0/Az.Network/Remove-AzNetworkWatcherPacketCapture.md
@@ -268,6 +268,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Resize-AzVirtualNetworkGateway.md
+++ b/azps-1.8.0/Az.Network/Resize-AzVirtualNetworkGateway.md
@@ -132,4 +132,4 @@ You cannot resize from Basic/Standard/HighPerformance SKUs to the new VpnGw1/Vpn
 
 [Get-AzVpnClientPackage](./Get-AzVpnClientPackage.md)
 
-[Set-AzVirtualNetworkGatewayVpnClientConfig](./Set-AzVirtualNetworkGatewayVpnClientConfig.md)
+

--- a/azps-1.8.0/Az.Network/Set-AzApplicationGatewayConnectionDraining.md
+++ b/azps-1.8.0/Az.Network/Set-AzApplicationGatewayConnectionDraining.md
@@ -115,7 +115,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzApplicationGateway](./Get-AzApplicationGateway.md)
 
-[Get-AzApplicationGatewayBackendHttpSettings](./Get-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [Get-AzApplicationGatewayConnectionDraining](./Get-AzApplicationGatewayConnectionDraining.md)
 

--- a/azps-1.8.0/Az.Network/Set-AzNetworkWatcherConfigFlowLog.md
+++ b/azps-1.8.0/Az.Network/Set-AzNetworkWatcherConfigFlowLog.md
@@ -588,6 +588,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Start-AzNetworkWatcherResourceTroubleshooting.md
+++ b/azps-1.8.0/Az.Network/Start-AzNetworkWatcherResourceTroubleshooting.md
@@ -242,6 +242,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-1.8.0/Az.Network/Stop-AzNetworkWatcherPacketCapture.md
+++ b/azps-1.8.0/Az.Network/Stop-AzNetworkWatcherPacketCapture.md
@@ -266,6 +266,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-1.8.0/Az.Network/Test-AzNetworkWatcherConnectivity.md
+++ b/azps-1.8.0/Az.Network/Test-AzNetworkWatcherConnectivity.md
@@ -309,5 +309,4 @@ Keywords: azure, azurerm, arm, resource, connectivity, management, manager, netw
 [Get-AzNetworkWatcherReachabilityReport](./Get-AzNetworkWatcherReachabilityReport.md)
 [Get-AzNetworkWatcherReachabilityProvidersList](./Get-AzNetworkWatcherReachabilityProvidersList.md)
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-1.8.0/Az.Network/Test-AzNetworkWatcherIPFlow.md
+++ b/azps-1.8.0/Az.Network/Test-AzNetworkWatcherIPFlow.md
@@ -338,6 +338,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHub.md
+++ b/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHub.md
@@ -118,11 +118,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzNotificationHubAuthorizationRules](./Get-AzNotificationHubAuthorizationRules.md)
 
-[Get-AzNotificationHubListKeys](./Get-AzNotificationHubListKeys.md)
 
-[Get-AzNotificationHubPNSCredentials](./Get-AzNotificationHubPNSCredentials.md)
+
+
+
 
 [New-AzNotificationHub](./New-AzNotificationHub.md)
 

--- a/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHubListKey.md
+++ b/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHubListKey.md
@@ -135,6 +135,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzNotificationHubAuthorizationRules](./Get-AzNotificationHubAuthorizationRules.md)
+
 
 

--- a/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespace.md
+++ b/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespace.md
@@ -117,7 +117,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzNotificationHubsNamespaceAuthorizationRules](./Get-AzNotificationHubsNamespaceAuthorizationRules.md)
+
 
 [New-AzNotificationHubsNamespace](./New-AzNotificationHubsNamespace.md)
 

--- a/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespaceListKey.md
+++ b/azps-1.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespaceListKey.md
@@ -116,6 +116,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzNotificationHubsNamespace](./Get-AzNotificationHubsNamespace.md)
 
-[Get-AzNotificationHubsNamespaceAuthorizationRules](./Get-AzNotificationHubsNamespaceAuthorizationRules.md)
+
 
 

--- a/azps-1.8.0/Az.OperationalInsights/New-AzOperationalInsightsWorkspace.md
+++ b/azps-1.8.0/Az.OperationalInsights/New-AzOperationalInsightsWorkspace.md
@@ -245,6 +245,6 @@ A new pricing model has been released. If you are a CSP that means that you have
 
 [Azure Operational Insights Cmdlets](./Az.OperationalInsights.md)
 
-[Get-AzOperationalInsightsLinkTargets](./Get-AzOperationalInsightsLinkTargets.md)
+
 
 

--- a/azps-1.8.0/Az.RecoveryServices/Get-AzRecoveryServicesAsrProtectableItem.md
+++ b/azps-1.8.0/Az.RecoveryServices/Get-AzRecoveryServicesAsrProtectableItem.md
@@ -168,6 +168,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzRecoveryServicesAsrProtectionEntity](./Get-AzRecoveryServicesAsrProtectionEntity.md)
 
-[Set-AzRecoveryServicesAsrProtectionEntity](./Set-AzRecoveryServicesAsrProtectionEntity.md)
+
+

--- a/azps-1.8.0/Az.RecoveryServices/Get-AzRecoveryServicesBackupJob.md
+++ b/azps-1.8.0/Az.RecoveryServices/Get-AzRecoveryServicesBackupJob.md
@@ -248,7 +248,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzRecoveryServicesBackupJobDetails](./Get-AzRecoveryServicesBackupJobDetails.md)
+
 
 [Stop-AzRecoveryServicesBackupJob](./Stop-AzRecoveryServicesBackupJob.md)
 

--- a/azps-1.8.0/Az.RecoveryServices/Import-AzRecoveryServicesAsrVaultSettingsFile.md
+++ b/azps-1.8.0/Az.RecoveryServices/Import-AzRecoveryServicesAsrVaultSettingsFile.md
@@ -110,4 +110,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzRecoveryServicesAsrVaultSettingsFile](./Get-AzRecoveryServicesAsrVaultSettingsFile.md)
+

--- a/azps-1.8.0/Az.Resources/Export-AzResourceGroup.md
+++ b/azps-1.8.0/Az.Resources/Export-AzResourceGroup.md
@@ -206,6 +206,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResourceGroup](./Find-AzResourceGroup.md)
+
 
 

--- a/azps-1.8.0/Az.Resources/Get-AzADApplication.md
+++ b/azps-1.8.0/Az.Resources/Get-AzADApplication.md
@@ -252,7 +252,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzADApplication](./Remove-AzADApplication.md)
 
-[Set-AzADApplication](./Set-AzADApplication.md)
+
 
 [New-AzADApplication](./New-AzADApplication.md)
 

--- a/azps-1.8.0/Az.Resources/Get-AzADServicePrincipal.md
+++ b/azps-1.8.0/Az.Resources/Get-AzADServicePrincipal.md
@@ -275,7 +275,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzADServicePrincipal](./New-AzADServicePrincipal.md)
 
-[Set-AzADServicePrincipal](./Set-AzADServicePrincipal.md)
+
 
 [Remove-AzADServicePrincipal](./Remove-AzADServicePrincipal.md)
 

--- a/azps-1.8.0/Az.Resources/Get-AzADUser.md
+++ b/azps-1.8.0/Az.Resources/Get-AzADUser.md
@@ -254,7 +254,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzADUser](./New-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 
 [Remove-AzADUser](./Remove-AzADUser.md)
 

--- a/azps-1.8.0/Az.Resources/Get-AzResource.md
+++ b/azps-1.8.0/Az.Resources/Get-AzResource.md
@@ -344,7 +344,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Move-AzResource](./Move-AzResource.md)
 

--- a/azps-1.8.0/Az.Resources/Move-AzResource.md
+++ b/azps-1.8.0/Az.Resources/Move-AzResource.md
@@ -193,7 +193,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-1.8.0/Az.Resources/New-AzADUser.md
+++ b/azps-1.8.0/Az.Resources/New-AzADUser.md
@@ -199,6 +199,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzADUser](./Get-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 
 [Remove-AzADUser](./Remove-AzADUser.md)

--- a/azps-1.8.0/Az.Resources/New-AzResource.md
+++ b/azps-1.8.0/Az.Resources/New-AzResource.md
@@ -433,7 +433,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-1.8.0/Az.Resources/Remove-AzADApplication.md
+++ b/azps-1.8.0/Az.Resources/Remove-AzADApplication.md
@@ -230,7 +230,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, resource, group, t
 
 [Get-AzADApplication](./Get-AzADApplication.md)
 
-[Set-AzADApplication](./Set-AzADApplication.md)
+
 
 [Remove-AzADAppCredential](./Remove-AzADAppCredential.md)
 

--- a/azps-1.8.0/Az.Resources/Remove-AzADServicePrincipal.md
+++ b/azps-1.8.0/Az.Resources/Remove-AzADServicePrincipal.md
@@ -290,7 +290,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, resource, group, t
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
 
-[Set-AzADServicePrincipal](./Set-AzADServicePrincipal.md)
+
 
 [Remove-AzADApplication](./Remove-AzADApplication.md)
 

--- a/azps-1.8.0/Az.Resources/Remove-AzADUser.md
+++ b/azps-1.8.0/Az.Resources/Remove-AzADUser.md
@@ -248,5 +248,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzADUser](./Get-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 

--- a/azps-1.8.0/Az.Resources/Remove-AzResource.md
+++ b/azps-1.8.0/Az.Resources/Remove-AzResource.md
@@ -307,7 +307,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-1.8.0/Az.Resources/Set-AzResource.md
+++ b/azps-1.8.0/Az.Resources/Set-AzResource.md
@@ -466,7 +466,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-1.8.0/Az.Sql/New-AzSqlSyncGroup.md
+++ b/azps-1.8.0/Az.Sql/New-AzSqlSyncGroup.md
@@ -284,7 +284,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-AzSqlSyncGroup](./Set-AzSqlSyncGroup.md)
+
 
 [Remove-AzSqlSyncGroup](./Remove-AzSqlSyncGroup.md)
 

--- a/azps-1.8.0/Az.Sql/New-AzSqlSyncMember.md
+++ b/azps-1.8.0/Az.Sql/New-AzSqlSyncMember.md
@@ -384,7 +384,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzSqlSyncMember](./Get-AzSqlSyncMember.md)
 
-[Set-AzSqlSyncMember](./Set-AzSqlSyncMember.md)
+
 
 [Remove-AzSqlSyncMember](./Remove-AzSqlSyncMember.md)
 

--- a/azps-1.8.0/Az.Sql/Start-AzSqlDatabaseExecuteIndexRecommendation.md
+++ b/azps-1.8.0/Az.Sql/Start-AzSqlDatabaseExecuteIndexRecommendation.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzSqlDatabaseIndexRecommendations](./Get-AzSqlDatabaseIndexRecommendations.md)
+
 
 [Stop-AzSqlDatabaseExecuteIndexRecommendation](./Stop-AzSqlDatabaseExecuteIndexRecommendation.md)
 

--- a/azps-1.8.0/Az.Sql/Stop-AzSqlDatabaseExecuteIndexRecommendation.md
+++ b/azps-1.8.0/Az.Sql/Stop-AzSqlDatabaseExecuteIndexRecommendation.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzSqlDatabaseIndexRecommendations](./Get-AzSqlDatabaseIndexRecommendations.md)
+
 
 [Start-AzSqlDatabaseExecuteIndexRecommendation](./Start-AzSqlDatabaseExecuteIndexRecommendation.md)
 

--- a/azps-2.8.0/Az.ApiManagement/Get-AzApiManagementApiRelease.md
+++ b/azps-2.8.0/Az.ApiManagement/Get-AzApiManagementApiRelease.md
@@ -165,4 +165,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzApiManagementApiRelease](./Remove-AzApiManagementApiRelease.md)
 
-[Set-AzApiManagementApiRelease](./Set-AzApiManagementApiRelease.md)

--- a/azps-2.8.0/Az.ApiManagement/Get-AzApiManagementCache.md
+++ b/azps-2.8.0/Az.ApiManagement/Get-AzApiManagementCache.md
@@ -148,8 +148,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementCache](./Get-AzApiManagementCache)
 
-[Set-AzApiManagementCache](./Set-AzApiManagementCache.md)
+
+
 
 [Remove-AzApiManagementCache](./Remove-AzApiManagementCache.md)

--- a/azps-2.8.0/Az.ApiManagement/New-AzApiManagementApiRelease.md
+++ b/azps-2.8.0/Az.ApiManagement/New-AzApiManagementApiRelease.md
@@ -192,4 +192,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzApiManagementApiRelease](./Remove-AzApiManagementApiRelease.md)
 
-[Set-AzApiManagementApiRelease](./Set-AzApiManagementApiRelease.md)

--- a/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackend.md
+++ b/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackend.md
@@ -305,7 +305,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackendCredential](./New-AzApiManagementBackendCredential.md)
 

--- a/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackendCredential.md
+++ b/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackendCredential.md
@@ -147,7 +147,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackendProxy.md
+++ b/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackendProxy.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackendServiceFabric.md
+++ b/azps-2.8.0/Az.ApiManagement/New-AzApiManagementBackendServiceFabric.md
@@ -150,7 +150,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-2.8.0/Az.ApiManagement/New-AzApiManagementCache.md
+++ b/azps-2.8.0/Az.ApiManagement/New-AzApiManagementCache.md
@@ -186,8 +186,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementCache](./Get-AzApiManagementCache)
 
-[Set-AzApiManagementCache](./Set-AzApiManagementCache.md)
+
+
 
 [Remove-AzApiManagementCache](./Remove-AzApiManagementCache.md)

--- a/azps-2.8.0/Az.ApiManagement/Remove-AzApiManagementApiRelease.md
+++ b/azps-2.8.0/Az.ApiManagement/Remove-AzApiManagementApiRelease.md
@@ -190,4 +190,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzApiManagementApiRelease](./New-AzApiManagementApiRelease.md)
 
-[Set-AzApiManagementApiRelease](./Set-AzApiManagementApiRelease.md)

--- a/azps-2.8.0/Az.ApiManagement/Remove-AzApiManagementBackend.md
+++ b/azps-2.8.0/Az.ApiManagement/Remove-AzApiManagementBackend.md
@@ -145,7 +145,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-2.8.0/Az.ApiManagement/Remove-AzApiManagementCache.md
+++ b/azps-2.8.0/Az.ApiManagement/Remove-AzApiManagementCache.md
@@ -191,8 +191,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[New-AzApiManagementCache](./New-AzApiManagementCache)
 
-[Set-AzApiManagementCache](./Set-AzApiManagementCache.md)
+
+
 
 [Get-AzApiManagementCache](./Get-AzApiManagementCache.md)

--- a/azps-2.8.0/Az.ApiManagement/Set-AzApiManagementBackend.md
+++ b/azps-2.8.0/Az.ApiManagement/Set-AzApiManagementBackend.md
@@ -341,7 +341,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzApiManagementBackend](./Get-AzApiManagementBackend)
+
 
 [New-AzApiManagementBackend](./New-AzApiManagementBackend.md)
 

--- a/azps-2.8.0/Az.ApiManagement/Update-AzApiManagementCache.md
+++ b/azps-2.8.0/Az.ApiManagement/Update-AzApiManagementCache.md
@@ -254,7 +254,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[New-AzApiManagementCache](./New-AzApiManagementCache)
+
 
 [Get-AzApiManagementCache](./Get-AzApiManagementCache.md)
 

--- a/azps-2.8.0/Az.Batch/Disable-AzBatchComputeNodeScheduling.md
+++ b/azps-2.8.0/Az.Batch/Disable-AzBatchComputeNodeScheduling.md
@@ -195,7 +195,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Enable-AzBatchComputeNodeScheduling](./Enable-AzBatchComputeNodeScheduling.md)
 

--- a/azps-2.8.0/Az.Batch/Disable-AzBatchJob.md
+++ b/azps-2.8.0/Az.Batch/Disable-AzBatchJob.md
@@ -124,7 +124,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/Disable-AzBatchJobSchedule.md
+++ b/azps-2.8.0/Az.Batch/Disable-AzBatchJobSchedule.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-2.8.0/Az.Batch/Enable-AzBatchJobSchedule.md
+++ b/azps-2.8.0/Az.Batch/Enable-AzBatchJobSchedule.md
@@ -101,7 +101,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Disable-AzBatchJobSchedule](./Disable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-2.8.0/Az.Batch/Enable-AzBatchTask.md
+++ b/azps-2.8.0/Az.Batch/Enable-AzBatchTask.md
@@ -178,7 +178,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchTask](./Get-AzBatchTask.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchCertificate.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchCertificate.md
@@ -233,7 +233,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchCertificate](./New-AzBatchCertificate.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchJob.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchJob.md
@@ -295,7 +295,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchJobSchedule.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchJobSchedule.md
@@ -231,7 +231,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchJobSchedule](./New-AzBatchJobSchedule.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchJobStatistic.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchJobStatistic.md
@@ -98,10 +98,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPoolStatistic](./Get-AzBatchPoolStatistic.md)
 
-[Get-AzBatchPoolUsageMetrics](./Get-AzBatchPoolUsageMetrics.md)
+
 
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchNodeAgentSku.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchNodeAgentSku.md
@@ -122,6 +122,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchNodeFile.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchNodeFile.md
@@ -352,7 +352,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchNodeFileContent.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchNodeFileContent.md
@@ -323,7 +323,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchNodeFile](./Get-AzBatchNodeFile.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchPool.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchPool.md
@@ -234,7 +234,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchPool](./New-AzBatchPool.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchPoolStatistic.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchPoolStatistic.md
@@ -99,9 +99,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
 
-[Get-AzBatchPoolUsageMetrics](./Get-AzBatchPoolUsageMetrics.md)
+
+
 
 [Get-AzBatchJobStatistic](./Get-AzBatchJobStatistic.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchPoolUsageMetric.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchPoolUsageMetric.md
@@ -185,10 +185,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
 
-[Get-AzBatchPoolStatistics](./Get-AzBatchPoolStatistics.md)
 
-[Get-AzBatchJobStatistics](./Get-AzBatchJobStatistics.md)
+
+
+
 
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchRemoteDesktopProtocolFile.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchRemoteDesktopProtocolFile.md
@@ -201,7 +201,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchRemoteLoginSetting.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchRemoteLoginSetting.md
@@ -158,7 +158,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchTask.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchTask.md
@@ -277,7 +277,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/Get-AzBatchTaskCount.md
+++ b/azps-2.8.0/Az.Batch/Get-AzBatchTaskCount.md
@@ -133,7 +133,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchAccountKey.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchAccountKey.md
@@ -128,7 +128,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Azure Batch Cmdlets](./Az.Batch.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchCertificate.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchCertificate.md
@@ -147,7 +147,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchCertificate](./Get-AzBatchCertificate.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Remove-AzBatchCertificate](./Remove-AzBatchCertificate.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchComputeNodeUser.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchComputeNodeUser.md
@@ -208,7 +208,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchJob.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchJob.md
@@ -304,7 +304,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchJobSchedule.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchJobSchedule.md
@@ -177,7 +177,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchPool.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchPool.md
@@ -505,7 +505,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-2.8.0/Az.Batch/New-AzBatchTask.md
+++ b/azps-2.8.0/Az.Batch/New-AzBatchTask.md
@@ -464,7 +464,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchCertificate.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchCertificate.md
@@ -158,7 +158,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchCertificate](./Get-AzBatchCertificate.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchCertificate](./New-AzBatchCertificate.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchComputeNode.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchComputeNode.md
@@ -239,7 +239,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchComputeNode](./Get-AzBatchComputeNode.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchComputeNodeUser.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchComputeNodeUser.md
@@ -165,7 +165,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzBatchComputeNodeUser](./New-AzBatchComputeNodeUser.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Azure Batch Cmdlets](./Az.Batch.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchJob.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchJob.md
@@ -163,7 +163,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchJob](./New-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchNodeFile.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchNodeFile.md
@@ -272,7 +272,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchNodeFile](./Get-AzBatchNodeFile.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchPool.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchPool.md
@@ -154,7 +154,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-2.8.0/Az.Batch/Remove-AzBatchTask.md
+++ b/azps-2.8.0/Az.Batch/Remove-AzBatchTask.md
@@ -198,7 +198,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchTask](./Get-AzBatchTask.md)
 

--- a/azps-2.8.0/Az.Batch/Set-AzBatchComputeNodeUser.md
+++ b/azps-2.8.0/Az.Batch/Set-AzBatchComputeNodeUser.md
@@ -157,7 +157,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchComputeNodeUser](./New-AzBatchComputeNodeUser.md)
 

--- a/azps-2.8.0/Az.Batch/Set-AzBatchJob.md
+++ b/azps-2.8.0/Az.Batch/Set-AzBatchJob.md
@@ -109,7 +109,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchJob](./New-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/Set-AzBatchPool.md
+++ b/azps-2.8.0/Az.Batch/Set-AzBatchPool.md
@@ -107,7 +107,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchPool](./New-AzBatchPool.md)
 

--- a/azps-2.8.0/Az.Batch/Set-AzBatchPoolOSVersion.md
+++ b/azps-2.8.0/Az.Batch/Set-AzBatchPoolOSVersion.md
@@ -113,6 +113,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 

--- a/azps-2.8.0/Az.Batch/Set-AzBatchTask.md
+++ b/azps-2.8.0/Az.Batch/Set-AzBatchTask.md
@@ -106,7 +106,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzBatchTask](./Get-AzBatchTask.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [New-AzBatchTask](./New-AzBatchTask.md)
 

--- a/azps-2.8.0/Az.Batch/Start-AzBatchPoolResize.md
+++ b/azps-2.8.0/Az.Batch/Start-AzBatchPoolResize.md
@@ -176,7 +176,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-2.8.0/Az.Batch/Stop-AzBatchCertificateDeletion.md
+++ b/azps-2.8.0/Az.Batch/Stop-AzBatchCertificateDeletion.md
@@ -115,7 +115,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Remove-AzBatchCertificate](./Remove-AzBatchCertificate.md)
 

--- a/azps-2.8.0/Az.Batch/Stop-AzBatchJob.md
+++ b/azps-2.8.0/Az.Batch/Stop-AzBatchJob.md
@@ -120,7 +120,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJob](./Enable-AzBatchJob.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJob](./Get-AzBatchJob.md)
 

--- a/azps-2.8.0/Az.Batch/Stop-AzBatchJobSchedule.md
+++ b/azps-2.8.0/Az.Batch/Stop-AzBatchJobSchedule.md
@@ -102,7 +102,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchJobSchedule](./Enable-AzBatchJobSchedule.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchJobSchedule](./Get-AzBatchJobSchedule.md)
 

--- a/azps-2.8.0/Az.Batch/Stop-AzBatchPoolResize.md
+++ b/azps-2.8.0/Az.Batch/Stop-AzBatchPoolResize.md
@@ -108,7 +108,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Get-AzBatchPool](./Get-AzBatchPool.md)
 

--- a/azps-2.8.0/Az.Batch/Test-AzBatchAutoScale.md
+++ b/azps-2.8.0/Az.Batch/Test-AzBatchAutoScale.md
@@ -121,7 +121,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Enable-AzBatchAutoScale](./Enable-AzBatchAutoScale.md)
 
-[Get-AzBatchAccountKeys](./Get-AzBatchAccountKeys.md)
+
 
 [Azure Batch Cmdlets](./Az.Batch.md)
 

--- a/azps-2.8.0/Az.Compute/Get-AzVMBootDiagnosticsData.md
+++ b/azps-2.8.0/Az.Compute/Get-AzVMBootDiagnosticsData.md
@@ -162,6 +162,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-AzVMBootDiagnostics](./Set-AzVMBootDiagnostics.md)
+
 
 

--- a/azps-2.8.0/Az.DataFactory/Get-AzDataFactoryV2DataFlow.md
+++ b/azps-2.8.0/Az.DataFactory/Get-AzDataFactoryV2DataFlow.md
@@ -172,6 +172,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, data, factories
 
 ## RELATED LINKS
 
-[Set-AzDataFactoryDataFlow](./Set-AzDataFactoryDataFlow.md)
 
-[Remove-AzDataFactoryDataFlow](./Remove-AzDataFactoryDataFlow.md)
+

--- a/azps-2.8.0/Az.DataFactory/Remove-AzDataFactoryV2DataFlow.md
+++ b/azps-2.8.0/Az.DataFactory/Remove-AzDataFactoryV2DataFlow.md
@@ -223,7 +223,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, data, factories
 
 ## RELATED LINKS
 
-[Get-AzDataFactoryDataFlow](./Get-AzDataFactoryDataFlow.md)
 
-[Set-AzDataFactoryDataFlow](./Set-AzDataFactoryDataFlow.md)
+
+
 

--- a/azps-2.8.0/Az.DataFactory/Set-AzDataFactoryV2DataFlow.md
+++ b/azps-2.8.0/Az.DataFactory/Set-AzDataFactoryV2DataFlow.md
@@ -198,6 +198,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, data, factories
 
 ## RELATED LINKS
 
-[Get-AzDataFactoryDataFlow](./Get-AzDataFactoryDataFlow.md)
 
-[Remove-AzDataFactoryDataFlow](./Remove-AzDataFactoryDataFlow.md)
+
+

--- a/azps-2.8.0/Az.FrontDoor/Get-AzFrontDoorWafPolicy.md
+++ b/azps-2.8.0/Az.FrontDoor/Get-AzFrontDoorWafPolicy.md
@@ -111,5 +111,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzFrontDoorWafPolicy](./New-AzFrontDoorWafPolicy.md)
-[Set-AzFrontDoorWafPolicy](./Set-AzFrontDoorWafPolicy.md)
+
 [Remove-AzFrontDoorWafPolicy](./Remove-AzFrontDoorWafPolicy.md)

--- a/azps-2.8.0/Az.FrontDoor/New-AzFrontDoorWafCustomRuleObject.md
+++ b/azps-2.8.0/Az.FrontDoor/New-AzFrontDoorWafCustomRuleObject.md
@@ -176,4 +176,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzFrontDoorWafPolicy](./New-AzFrontDoorWafPolicy.md)
-[Set-AzFrontDoorWafPolicy](./Set-AzFrontDoorWafPolicy.md)
+

--- a/azps-2.8.0/Az.FrontDoor/New-AzFrontDoorWafManagedRuleObject.md
+++ b/azps-2.8.0/Az.FrontDoor/New-AzFrontDoorWafManagedRuleObject.md
@@ -121,5 +121,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzFrontDoorWafPolicy](./New-AzFrontDoorWafPolicy.md)
-[Set-AzFrontDoorWafPolicy](./Set-AzFrontDoorWafPolicy.md)
+
 [New-AzFrontDoorWafRuleGroupOverrideObject](./New-AzFrontDoorWafRuleGroupOverrideObject.md)

--- a/azps-2.8.0/Az.FrontDoor/New-AzFrontDoorWafPolicy.md
+++ b/azps-2.8.0/Az.FrontDoor/New-AzFrontDoorWafPolicy.md
@@ -238,7 +238,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-AzFrontDoorWafPolicy](./Set-AzFrontDoorWafPolicy.md)
+
 [Get-AzFrontDoorWafPolicy](./Get-AzFrontDoorWafPolicy.md)
 [Remove-AzFrontDoorWafPolicy](./Remove-AzFrontDoorWafPolicy.md)
 [New-AzFrontDoorWafManagedRuleObject](./New-AzFrontDoorWafManagedRuleObject.md)

--- a/azps-2.8.0/Az.KeyVault/Add-AzKeyVaultKey.md
+++ b/azps-2.8.0/Az.KeyVault/Add-AzKeyVaultKey.md
@@ -556,4 +556,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultKey](./Remove-AzKeyVaultKey.md)
 
-[Set-AzKeyVaultKeyAttribute](./Set-AzKeyVaultKeyAttribute.md)
+

--- a/azps-2.8.0/Az.KeyVault/Get-AzKeyVaultCertificate.md
+++ b/azps-2.8.0/Az.KeyVault/Get-AzKeyVaultCertificate.md
@@ -387,4 +387,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultCertificate](./Remove-AzKeyVaultCertificate.md)
 
-[Undo-AzKeyVaultSecretCertificate](./Undo-AzKeyVaultSecretCertificate.md)
+

--- a/azps-2.8.0/Az.KeyVault/Get-AzKeyVaultKey.md
+++ b/azps-2.8.0/Az.KeyVault/Get-AzKeyVaultKey.md
@@ -416,5 +416,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Undo-AzKeyVaultKeyRemoval](./Undo-AzKeyVaultKeyRemoval.md)
 
-[Set-AzKeyVaultKeyAttribute](./Set-AzKeyVaultKeyAttribute.md)
+
 

--- a/azps-2.8.0/Az.KeyVault/Remove-AzKeyVaultKey.md
+++ b/azps-2.8.0/Az.KeyVault/Remove-AzKeyVaultKey.md
@@ -240,7 +240,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzKeyVaultKey](./Get-AzKeyVaultKey.md)
 
-[Set-AzKeyVaultKeyAttribute](./Set-AzKeyVaultKeyAttribute.md)
+
 
 [Undo-AzKeyVaultKeyRemoval](./Undo-AzKeyVaultKeyRemoval.md)
 

--- a/azps-2.8.0/Az.KeyVault/Undo-AzKeyVaultSecretRemoval.md
+++ b/azps-2.8.0/Az.KeyVault/Undo-AzKeyVaultSecretRemoval.md
@@ -164,6 +164,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzKeyVaultSecret](./Remove-AzKeyVaultSecret.md)
 
-[Add-AzKeyVaultSecret](./Add-AzKeyVaultSecret.md)
+
 
 [Get-AzKeyVaultSecret](./Get-AzKeyVaultSecret.md)

--- a/azps-2.8.0/Az.Media/New-AzMediaServiceStorageConfig.md
+++ b/azps-2.8.0/Az.Media/New-AzMediaServiceStorageConfig.md
@@ -130,6 +130,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Sync-AzMediaServiceStorageKeys](./Sync-AzMediaServiceStorageKeys.md)
+
 
 

--- a/azps-2.8.0/Az.Media/Set-AzMediaServiceKey.md
+++ b/azps-2.8.0/Az.Media/Set-AzMediaServiceKey.md
@@ -149,6 +149,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzMediaServiceKeys](./Get-AzMediaServiceKeys.md)
+
 
 

--- a/azps-2.8.0/Az.Monitor/Get-AzActivityLogAlert.md
+++ b/azps-2.8.0/Az.Monitor/Get-AzActivityLogAlert.md
@@ -130,7 +130,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Set-AzActivityLogAlert](./Set-AzActivityLogAlert.md)
 
-[Update-AzActivityLogAlert](./Update-AzActivityLogAlert.md)
+
 
 [Remove-AzActivityLogAlert](./Remove-AzActivityLogAlert.md)
 

--- a/azps-2.8.0/Az.Monitor/Get-AzAlertHistory.md
+++ b/azps-2.8.0/Az.Monitor/Get-AzAlertHistory.md
@@ -393,7 +393,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-2.8.0/Az.Monitor/Get-AzAlertRule.md
+++ b/azps-2.8.0/Az.Monitor/Get-AzAlertRule.md
@@ -156,7 +156,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-2.8.0/Az.Monitor/New-AzAlertRuleEmail.md
+++ b/azps-2.8.0/Az.Monitor/New-AzAlertRuleEmail.md
@@ -110,7 +110,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-2.8.0/Az.Monitor/New-AzAlertRuleWebhook.md
+++ b/azps-2.8.0/Az.Monitor/New-AzAlertRuleWebhook.md
@@ -103,7 +103,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Add-AzLogAlertRule](./Add-AzLogAlertRule.md)
+
 
 [Add-AzMetricAlertRule](./Add-AzMetricAlertRule.md)
 

--- a/azps-2.8.0/Az.Network/Get-AzApplicationGatewayConnectionDraining.md
+++ b/azps-2.8.0/Az.Network/Get-AzApplicationGatewayConnectionDraining.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzApplicationGateway](./Get-AzApplicationGateway.md)
 
-[Get-AzApplicationGatewayBackendHttpSettings](./Get-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [New-AzApplicationGatewayConnectionDraining](./New-AzApplicationGatewayConnectionDraining.md)
 

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcher.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcher.md
@@ -193,6 +193,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherFlowLogStatus.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherFlowLogStatus.md
@@ -269,6 +269,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherNextHop.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherNextHop.md
@@ -277,6 +277,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherPacketCapture.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherPacketCapture.md
@@ -240,7 +240,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+
 

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherReachabilityProvidersList.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherReachabilityProvidersList.md
@@ -311,6 +311,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherReachabilityReport.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherReachabilityReport.md
@@ -360,6 +360,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherSecurityGroupView.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherSecurityGroupView.md
@@ -223,6 +223,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherTopology.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherTopology.md
@@ -298,7 +298,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+
 

--- a/azps-2.8.0/Az.Network/Get-AzNetworkWatcherTroubleshootingResult.md
+++ b/azps-2.8.0/Az.Network/Get-AzNetworkWatcherTroubleshootingResult.md
@@ -215,6 +215,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Get-AzVpnClientPackage.md
+++ b/azps-2.8.0/Az.Network/Get-AzVpnClientPackage.md
@@ -118,6 +118,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Resize-AzVirtualNetworkGateway](./Resize-AzVirtualNetworkGateway.md)
 
-[Set-AzVirtualNetworkGatewayVpnClientConfig](./Set-AzVirtualNetworkGatewayVpnClientConfig.md)
+
 
 

--- a/azps-2.8.0/Az.Network/Invoke-AzNetworkWatcherNetworkConfigurationDiagnostic.md
+++ b/azps-2.8.0/Az.Network/Invoke-AzNetworkWatcherNetworkConfigurationDiagnostic.md
@@ -308,6 +308,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/New-AzApplicationGateway.md
+++ b/azps-2.8.0/Az.Network/New-AzApplicationGateway.md
@@ -773,7 +773,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzApplicationGatewayBackendAddressPool](./New-AzApplicationGatewayBackendAddressPool.md)
 
-[New-AzApplicationGatewayBackendHttpSettings](./New-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [New-AzApplicationGatewayFrontendIPConfig](./New-AzApplicationGatewayFrontendIPConfig.md)
 

--- a/azps-2.8.0/Az.Network/New-AzApplicationGatewayPathRuleConfig.md
+++ b/azps-2.8.0/Az.Network/New-AzApplicationGatewayPathRuleConfig.md
@@ -271,7 +271,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzApplicationGatewayBackendAddressPool](./New-AzApplicationGatewayBackendAddressPool.md)
 
-[New-AzApplicationGatewayBackendHttpSettings](./New-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [New-AzApplicationGatewayPathRuleConfig](./New-AzApplicationGatewayPathRuleConfig.md)
 

--- a/azps-2.8.0/Az.Network/New-AzNetworkWatcher.md
+++ b/azps-2.8.0/Az.Network/New-AzNetworkWatcher.md
@@ -217,6 +217,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/New-AzNetworkWatcherNetworkConfigurationDiagnosticProfile.md
+++ b/azps-2.8.0/Az.Network/New-AzNetworkWatcherNetworkConfigurationDiagnosticProfile.md
@@ -225,6 +225,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/New-AzNetworkWatcherPacketCapture.md
+++ b/azps-2.8.0/Az.Network/New-AzNetworkWatcherPacketCapture.md
@@ -391,8 +391,8 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+
 
 

--- a/azps-2.8.0/Az.Network/New-AzNetworkWatcherProtocolConfiguration.md
+++ b/azps-2.8.0/Az.Network/New-AzNetworkWatcherProtocolConfiguration.md
@@ -205,6 +205,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/New-AzPacketCaptureFilterConfig.md
+++ b/azps-2.8.0/Az.Network/New-AzPacketCaptureFilterConfig.md
@@ -216,6 +216,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-2.8.0/Az.Network/Remove-AzApplicationGatewayConnectionDraining.md
+++ b/azps-2.8.0/Az.Network/Remove-AzApplicationGatewayConnectionDraining.md
@@ -84,7 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzApplicationGateway](./Get-AzApplicationGateway.md)
 
-[Get-AzApplicationGatewayBackendHttpSettings](./Get-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [Get-AzApplicationGatewayConnectionDraining](./Get-AzApplicationGatewayConnectionDraining.md)
 

--- a/azps-2.8.0/Az.Network/Remove-AzNetworkWatcher.md
+++ b/azps-2.8.0/Az.Network/Remove-AzNetworkWatcher.md
@@ -253,6 +253,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Remove-AzNetworkWatcherPacketCapture.md
+++ b/azps-2.8.0/Az.Network/Remove-AzNetworkWatcherPacketCapture.md
@@ -268,6 +268,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Resize-AzVirtualNetworkGateway.md
+++ b/azps-2.8.0/Az.Network/Resize-AzVirtualNetworkGateway.md
@@ -132,4 +132,4 @@ You cannot resize from Basic/Standard/HighPerformance SKUs to the new VpnGw1/Vpn
 
 [Get-AzVpnClientPackage](./Get-AzVpnClientPackage.md)
 
-[Set-AzVirtualNetworkGatewayVpnClientConfig](./Set-AzVirtualNetworkGatewayVpnClientConfig.md)
+

--- a/azps-2.8.0/Az.Network/Set-AzApplicationGatewayConnectionDraining.md
+++ b/azps-2.8.0/Az.Network/Set-AzApplicationGatewayConnectionDraining.md
@@ -115,7 +115,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzApplicationGateway](./Get-AzApplicationGateway.md)
 
-[Get-AzApplicationGatewayBackendHttpSettings](./Get-AzApplicationGatewayBackendHttpSettings.md)
+
 
 [Get-AzApplicationGatewayConnectionDraining](./Get-AzApplicationGatewayConnectionDraining.md)
 

--- a/azps-2.8.0/Az.Network/Set-AzNetworkWatcherConfigFlowLog.md
+++ b/azps-2.8.0/Az.Network/Set-AzNetworkWatcherConfigFlowLog.md
@@ -588,6 +588,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Start-AzNetworkWatcherResourceTroubleshooting.md
+++ b/azps-2.8.0/Az.Network/Start-AzNetworkWatcherResourceTroubleshooting.md
@@ -242,6 +242,5 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-2.8.0/Az.Network/Stop-AzNetworkWatcherPacketCapture.md
+++ b/azps-2.8.0/Az.Network/Stop-AzNetworkWatcherPacketCapture.md
@@ -266,6 +266,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.Network/Test-AzNetworkWatcherConnectivity.md
+++ b/azps-2.8.0/Az.Network/Test-AzNetworkWatcherConnectivity.md
@@ -309,5 +309,4 @@ Keywords: azure, azurerm, arm, resource, connectivity, management, manager, netw
 [Get-AzNetworkWatcherReachabilityReport](./Get-AzNetworkWatcherReachabilityReport.md)
 [Get-AzNetworkWatcherReachabilityProvidersList](./Get-AzNetworkWatcherReachabilityProvidersList.md)
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+

--- a/azps-2.8.0/Az.Network/Test-AzNetworkWatcherIPFlow.md
+++ b/azps-2.8.0/Az.Network/Test-AzNetworkWatcherIPFlow.md
@@ -338,6 +338,6 @@ Keywords: azure, azurerm, arm, resource, management, manager, network, networkin
 
 [Get-AzNetworkWatcherFlowLogStatus](./Get-AzNetworkWatcherFlowLogStatus.md)
 
-[Get-AzNetworkWatcherConnectionMonitorReport](./Get-AzNetworkWatcherConnectionMonitorReport)
 
-[Get-AzNetworkWatcherConnectionMonitor](./Get-AzNetworkWatcherConnectionMonitor)
+
+

--- a/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHub.md
+++ b/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHub.md
@@ -118,11 +118,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzNotificationHubAuthorizationRules](./Get-AzNotificationHubAuthorizationRules.md)
 
-[Get-AzNotificationHubListKeys](./Get-AzNotificationHubListKeys.md)
 
-[Get-AzNotificationHubPNSCredentials](./Get-AzNotificationHubPNSCredentials.md)
+
+
+
 
 [New-AzNotificationHub](./New-AzNotificationHub.md)
 

--- a/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHubListKey.md
+++ b/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHubListKey.md
@@ -135,6 +135,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzNotificationHubAuthorizationRules](./Get-AzNotificationHubAuthorizationRules.md)
+
 
 

--- a/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespace.md
+++ b/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespace.md
@@ -117,7 +117,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzNotificationHubsNamespaceAuthorizationRules](./Get-AzNotificationHubsNamespaceAuthorizationRules.md)
+
 
 [New-AzNotificationHubsNamespace](./New-AzNotificationHubsNamespace.md)
 

--- a/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespaceListKey.md
+++ b/azps-2.8.0/Az.NotificationHubs/Get-AzNotificationHubsNamespaceListKey.md
@@ -116,6 +116,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzNotificationHubsNamespace](./Get-AzNotificationHubsNamespace.md)
 
-[Get-AzNotificationHubsNamespaceAuthorizationRules](./Get-AzNotificationHubsNamespaceAuthorizationRules.md)
+
 
 

--- a/azps-2.8.0/Az.OperationalInsights/New-AzOperationalInsightsWorkspace.md
+++ b/azps-2.8.0/Az.OperationalInsights/New-AzOperationalInsightsWorkspace.md
@@ -247,6 +247,6 @@ A new pricing model has been released. If you are a CSP that means that you have
 
 [Azure Operational Insights Cmdlets](./Az.OperationalInsights.md)
 
-[Get-AzOperationalInsightsLinkTargets](./Get-AzOperationalInsightsLinkTargets.md)
+
 
 

--- a/azps-2.8.0/Az.RecoveryServices/Get-AzRecoveryServicesAsrProtectableItem.md
+++ b/azps-2.8.0/Az.RecoveryServices/Get-AzRecoveryServicesAsrProtectableItem.md
@@ -168,6 +168,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzRecoveryServicesAsrProtectionEntity](./Get-AzRecoveryServicesAsrProtectionEntity.md)
 
-[Set-AzRecoveryServicesAsrProtectionEntity](./Set-AzRecoveryServicesAsrProtectionEntity.md)
+
+

--- a/azps-2.8.0/Az.RecoveryServices/Import-AzRecoveryServicesAsrVaultSettingsFile.md
+++ b/azps-2.8.0/Az.RecoveryServices/Import-AzRecoveryServicesAsrVaultSettingsFile.md
@@ -110,4 +110,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzRecoveryServicesAsrVaultSettingsFile](./Get-AzRecoveryServicesAsrVaultSettingsFile.md)
+

--- a/azps-2.8.0/Az.Resources/Export-AzResourceGroup.md
+++ b/azps-2.8.0/Az.Resources/Export-AzResourceGroup.md
@@ -269,6 +269,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResourceGroup](./Find-AzResourceGroup.md)
+
 
 

--- a/azps-2.8.0/Az.Resources/Get-AzADApplication.md
+++ b/azps-2.8.0/Az.Resources/Get-AzADApplication.md
@@ -252,7 +252,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzADApplication](./Remove-AzADApplication.md)
 
-[Set-AzADApplication](./Set-AzADApplication.md)
+
 
 [New-AzADApplication](./New-AzADApplication.md)
 

--- a/azps-2.8.0/Az.Resources/Get-AzADServicePrincipal.md
+++ b/azps-2.8.0/Az.Resources/Get-AzADServicePrincipal.md
@@ -275,7 +275,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzADServicePrincipal](./New-AzADServicePrincipal.md)
 
-[Set-AzADServicePrincipal](./Set-AzADServicePrincipal.md)
+
 
 [Remove-AzADServicePrincipal](./Remove-AzADServicePrincipal.md)
 

--- a/azps-2.8.0/Az.Resources/Get-AzADUser.md
+++ b/azps-2.8.0/Az.Resources/Get-AzADUser.md
@@ -254,7 +254,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzADUser](./New-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 
 [Remove-AzADUser](./Remove-AzADUser.md)
 

--- a/azps-2.8.0/Az.Resources/Get-AzResource.md
+++ b/azps-2.8.0/Az.Resources/Get-AzResource.md
@@ -344,7 +344,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Move-AzResource](./Move-AzResource.md)
 

--- a/azps-2.8.0/Az.Resources/Move-AzResource.md
+++ b/azps-2.8.0/Az.Resources/Move-AzResource.md
@@ -193,7 +193,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-2.8.0/Az.Resources/New-AzADUser.md
+++ b/azps-2.8.0/Az.Resources/New-AzADUser.md
@@ -199,6 +199,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzADUser](./Get-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 
 [Remove-AzADUser](./Remove-AzADUser.md)

--- a/azps-2.8.0/Az.Resources/New-AzResource.md
+++ b/azps-2.8.0/Az.Resources/New-AzResource.md
@@ -433,7 +433,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-2.8.0/Az.Resources/Remove-AzADApplication.md
+++ b/azps-2.8.0/Az.Resources/Remove-AzADApplication.md
@@ -230,7 +230,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, resource, group, t
 
 [Get-AzADApplication](./Get-AzADApplication.md)
 
-[Set-AzADApplication](./Set-AzADApplication.md)
+
 
 [Remove-AzADAppCredential](./Remove-AzADAppCredential.md)
 

--- a/azps-2.8.0/Az.Resources/Remove-AzADServicePrincipal.md
+++ b/azps-2.8.0/Az.Resources/Remove-AzADServicePrincipal.md
@@ -290,7 +290,7 @@ Keywords: azure, azurerm, arm, resource, management, manager, resource, group, t
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
 
-[Set-AzADServicePrincipal](./Set-AzADServicePrincipal.md)
+
 
 [Remove-AzADApplication](./Remove-AzADApplication.md)
 

--- a/azps-2.8.0/Az.Resources/Remove-AzADUser.md
+++ b/azps-2.8.0/Az.Resources/Remove-AzADUser.md
@@ -248,5 +248,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzADUser](./Get-AzADUser.md)
 
-[Set-AzADUser](./Set-AzADUser.md)
+
 

--- a/azps-2.8.0/Az.Resources/Remove-AzResource.md
+++ b/azps-2.8.0/Az.Resources/Remove-AzResource.md
@@ -307,7 +307,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-2.8.0/Az.Resources/Set-AzResource.md
+++ b/azps-2.8.0/Az.Resources/Set-AzResource.md
@@ -466,7 +466,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Find-AzResource](./Find-AzResource.md)
+
 
 [Get-AzResource](./Get-AzResource.md)
 

--- a/azps-2.8.0/Az.Sql/Get-AzSqlDatabaseAdvancedThreatProtectionSettings.md
+++ b/azps-2.8.0/Az.Sql/Get-AzSqlDatabaseAdvancedThreatProtectionSettings.md
@@ -152,7 +152,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Remove-AzSqlDatabaseAdvancedThreatProtectionSettings](./Remove-AzSqlDatabaseAdvancedThreatProtectionSettings.md)
+
 
 
 

--- a/azps-2.8.0/Az.Sql/Get-AzSqlServerAdvancedThreatProtectionSettings.md
+++ b/azps-2.8.0/Az.Sql/Get-AzSqlServerAdvancedThreatProtectionSettings.md
@@ -135,7 +135,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Remove-AzSqlDatabaseAdvancedThreatProtectionSettings](./Remove-AzSqlDatabaseAdvancedThreatProtectionSettings.md)
+
 
 [SQL Database Documentation](https://docs.microsoft.com/azure/sql-database/)
 

--- a/azps-2.8.0/Az.Sql/New-AzSqlSyncGroup.md
+++ b/azps-2.8.0/Az.Sql/New-AzSqlSyncGroup.md
@@ -284,7 +284,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-AzSqlSyncGroup](./Set-AzSqlSyncGroup.md)
+
 
 [Remove-AzSqlSyncGroup](./Remove-AzSqlSyncGroup.md)
 

--- a/azps-2.8.0/Az.Sql/New-AzSqlSyncMember.md
+++ b/azps-2.8.0/Az.Sql/New-AzSqlSyncMember.md
@@ -384,7 +384,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzSqlSyncMember](./Get-AzSqlSyncMember.md)
 
-[Set-AzSqlSyncMember](./Set-AzSqlSyncMember.md)
+
 
 [Remove-AzSqlSyncMember](./Remove-AzSqlSyncMember.md)
 

--- a/azps-2.8.0/Az.Sql/Start-AzSqlDatabaseExecuteIndexRecommendation.md
+++ b/azps-2.8.0/Az.Sql/Start-AzSqlDatabaseExecuteIndexRecommendation.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzSqlDatabaseIndexRecommendations](./Get-AzSqlDatabaseIndexRecommendations.md)
+
 
 [Stop-AzSqlDatabaseExecuteIndexRecommendation](./Stop-AzSqlDatabaseExecuteIndexRecommendation.md)
 

--- a/azps-2.8.0/Az.Sql/Stop-AzSqlDatabaseExecuteIndexRecommendation.md
+++ b/azps-2.8.0/Az.Sql/Stop-AzSqlDatabaseExecuteIndexRecommendation.md
@@ -125,7 +125,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzSqlDatabaseIndexRecommendations](./Get-AzSqlDatabaseIndexRecommendations.md)
+
 
 [Start-AzSqlDatabaseExecuteIndexRecommendation](./Start-AzSqlDatabaseExecuteIndexRecommendation.md)
 

--- a/azps-2.8.0/Az.Sql/Update-AzSqlDatabaseAdvancedThreatProtectionSettings.md
+++ b/azps-2.8.0/Az.Sql/Update-AzSqlDatabaseAdvancedThreatProtectionSettings.md
@@ -249,7 +249,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzSqlDatabaseThreatDetectionsettings](./Get-AzSqlServerThreatDetectionsettings.md)
 
-[Remove-AzSqlDatabaseThreatDetectionsettings](./Remove-AzSqlDatabaseThreatDetectionsettings.md)
+
 
 [SQL Database Documentation](https://docs.microsoft.com/azure/sql-database/)
 

--- a/azps-2.8.0/Az.Sql/Update-AzSqlServerAdvancedThreatProtectionSettings.md
+++ b/azps-2.8.0/Az.Sql/Update-AzSqlServerAdvancedThreatProtectionSettings.md
@@ -231,7 +231,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Get-AzSqlServerThreatDetectionsettings](./Get-AzSqlServerThreatDetectionsettings.md)
+
 
 [Remove-AzSqlServerThreatDetectionsettings](03e90cd1-6ae2-4134-bc5e-28cc080614c9)
 

--- a/azurermps-2.5.0/AzureRm.Resources/New-AzureRmADUser.md
+++ b/azurermps-2.5.0/AzureRm.Resources/New-AzureRmADUser.md
@@ -197,6 +197,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Get-AzureRmADUser](./Get-AzureRmADUser.md)
 
-[Set-AzureRmADUser](./Set-AzureRmADUser.md)
-
 [Remove-AzureRmADUser](./Remove-AzureRmADUser.md)


### PR DESCRIPTION
…(248646)

As these are invalid file links, the build pipeline has no knowledge about the correct file links and how to fix it, so it can hardly be fixed from the build pipeline's side. 

Take the same example I mentioned below, the source markdown Add-AzApiManagementRegion.md contains one file link at the last line:

[Update-AzApiManagementDeployment](./Update-AzApiManagementDeployment.md)


However, Update-AzApiManagementDeployment.md doesn't exist in the same folder, so it will lead to 404 page.

Personally, I would suggest to fix this kind of content issue before we switch to the new SDP build pipeline, otherwise you'll always see lots of build warnings after every OPS build. However, the final decision is up to your team.

....

request to raise the priority for this ask. This is the predecessor of docfx v3 migration and we are targeting to switch the pipeline before the end of Aug. If we can not make this done, this will block docfx v3 migration, which will improve the build performance huge, which target to make that happen before the end of Nov. 