### PR TITLE
Simplify (and correct) examples for exporting Service Principal secrets

### DIFF
--- a/docs-conceptual/azps-0.10.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-0.10.0/create-azure-service-principal-azureps.md
@@ -44,8 +44,7 @@ The returned object contains the `Secret` member, which is a `SecureString` cont
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes `Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential` objects. These objects must have a valid `StartDate` and `EndDate`, and take a plaintext `Password`. When creating a password, make sure you follow the [Azure Active Directory password rules and restrictions](/azure/active-directory/active-directory-passwords-policy). Don't use a weak password or reuse a password.
@@ -143,7 +142,7 @@ To sign in with a service principal using a password:
 ```azurepowershell-interactive
 # Use the application ID as the username, and the secret as password
 $credentials = Get-Credential
-Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant <tenant ID> 
+Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant <tenant ID>
 ```
 
 Certificate-based authentication requires that Azure PowerShell can retrieve information from a local certificate

--- a/docs-conceptual/azps-1.8.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-1.8.0/create-azure-service-principal-azureps.md
@@ -44,8 +44,7 @@ The returned object contains the `Secret` member, which is a `SecureString` cont
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes `Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential` objects. These objects must have a valid `StartDate` and `EndDate`, and take a plaintext `Password`. When creating a password, make sure you follow the [Azure Active Directory password rules and restrictions](/azure/active-directory/active-directory-passwords-policy). Don't use a weak password or reuse a password.
@@ -143,7 +142,7 @@ To sign in with a service principal using a password:
 ```azurepowershell-interactive
 # Use the application ID as the username, and the secret as password
 $credentials = Get-Credential
-Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant <tenant ID> 
+Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant <tenant ID>
 ```
 
 Certificate-based authentication requires that Azure PowerShell can retrieve information from a local certificate

--- a/docs-conceptual/azps-2.8.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-2.8.0/create-azure-service-principal-azureps.md
@@ -44,8 +44,7 @@ The returned object contains the `Secret` member, which is a `SecureString` cont
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes `Microsoft.Azure.Commands.ActiveDirectory.PSADPasswordCredential` objects. These objects must have a valid `StartDate` and `EndDate`, and take a plaintext `Password`. When creating a password, make sure you follow the [Azure Active Directory password rules and restrictions](/azure/active-directory/active-directory-passwords-policy). Don't use a weak password or reuse a password.
@@ -143,7 +142,7 @@ To sign in with a service principal using a password:
 ```azurepowershell-interactive
 # Use the application ID as the username, and the secret as password
 $credentials = Get-Credential
-Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant <tenant ID> 
+Connect-AzAccount -ServicePrincipal -Credential $credentials -Tenant <tenant ID>
 ```
 
 Certificate-based authentication requires that Azure PowerShell can retrieve information from a local certificate

--- a/docs-conceptual/azps-3.8.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-3.8.0/create-azure-service-principal-azureps.md
@@ -56,8 +56,7 @@ principal. Its value _won't_ be displayed in the console output. If you lose the
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes

--- a/docs-conceptual/azps-4.5.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-4.5.0/create-azure-service-principal-azureps.md
@@ -56,8 +56,7 @@ principal. Its value _won't_ be displayed in the console output. If you lose the
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes

--- a/docs-conceptual/azps-4.6.0/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-4.6.0/create-azure-service-principal-azureps.md
@@ -56,8 +56,7 @@ principal. Its value _won't_ be displayed in the console output. If you lose the
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes

--- a/docs-conceptual/azps-4.6.1/create-azure-service-principal-azureps.md
+++ b/docs-conceptual/azps-4.6.1/create-azure-service-principal-azureps.md
@@ -56,8 +56,7 @@ principal. Its value _won't_ be displayed in the console output. If you lose the
 The following code will allow you to export the secret:
 
 ```azurepowershell-interactive
-$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
-$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
 ```
 
 For user-supplied passwords, the `-PasswordCredential` argument takes


### PR DESCRIPTION
The existing documentation supplies this snippet for converting a service principal's secret from a SecureString to a human readible string:

```powershell
$BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sp.Secret)
$UnsecureSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
```

This PR changes that to a simplified example using the native PowerShell cmdlet, [ConvertFrom-SecureString](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertfrom-securestring):

```powershell
$UnsecureSecret = ConvertFrom-SecureString $sp.Secret
```

This is much shorter and easier to follow, but also a colleague was trying to use the current example today and was getting incorrect results. This change did work for them.

![image](https://user-images.githubusercontent.com/6955786/91679419-5dd6b880-eb9c-11ea-884e-f484bb3426c0.png)