### PR TITLE
Unify case of Azs.AzureBridge.xx module under azurestakps-1.x.x

### DIFF
--- a/azurestackps-1.5.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-1.5.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.5.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.5.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.5.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-1.5.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.5.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.5.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.5.0/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.5.0/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.6.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-1.6.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.6.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.6.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.6.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-1.6.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.6.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.6.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.6.0/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.6.0/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.7.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-1.7.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.7.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.7.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.7.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-1.7.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.7.2/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.7.2/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.7.2/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.7.2/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-1.8.0/Azs.Azurebridge.Admin/Azs.AzureBridge.Admin.md
+++ b/azurestackps-1.8.0/Azs.Azurebridge.Admin/Azs.AzureBridge.Admin.md
@@ -1,16 +1,16 @@
 ---
-Module Name: Azs.Azurebridge.Admin
+Module Name: Azs.AzureBridge.Admin
 Module Guid: 82d2260a-95ae-44bb-af8b-afd67d38f6db
 Download Help Link: {{Please enter FwLink manually}}
 Help Version: {{Please enter version of help manually (X.X.X.X) format}}
 Locale: en-US
 ---
 
-# Azs.Azurebridge.Admin Module
+# Azs.AzureBridge.Admin Module
 ## Description
 Preview release of the AzureStack AzureBridge administrator module which allows you to manage your AzureStack marketplace items. 
 
-## Azs.Azurebridge.Admin Cmdlets
+## Azs.AzureBridge.Admin Cmdlets
 ### [Get-AzsAzureBridgeActivation](Get-AzsAzureBridgeActivation.md)
 Returns the Azure Bridge Activation.
 

--- a/azurestackps-1.8.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-1.8.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.8.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-1.8.0/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.8.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.0/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.8.0/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.1/Azs.Azurebridge.Admin/Azs.AzureBridge.Admin.md
+++ b/azurestackps-1.8.1/Azs.Azurebridge.Admin/Azs.AzureBridge.Admin.md
@@ -1,16 +1,16 @@
 ---
-Module Name: Azs.Azurebridge.Admin
+Module Name: Azs.AzureBridge.Admin
 Module Guid: 82d2260a-95ae-44bb-af8b-afd67d38f6db
 Download Help Link: {{Please enter FwLink manually}}
 Help Version: {{Please enter version of help manually (X.X.X.X) format}}
 Locale: en-US
 ---
 
-# Azs.Azurebridge.Admin Module
+# Azs.AzureBridge.Admin Module
 ## Description
 Preview release of the AzureStack AzureBridge administrator module which allows you to manage your AzureStack marketplace items. 
 
-## Azs.Azurebridge.Admin Cmdlets
+## Azs.AzureBridge.Admin Cmdlets
 ### [Get-AzsAzureBridgeActivation](Get-AzsAzureBridgeActivation.md)
 Returns the Azure Bridge Activation.
 

--- a/azurestackps-1.8.1/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-1.8.1/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.1/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.8.1/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.1/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-1.8.1/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.1/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.8.1/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.1/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.8.1/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.2/Azs.Azurebridge.Admin/Azs.AzureBridge.Admin.md
+++ b/azurestackps-1.8.2/Azs.Azurebridge.Admin/Azs.AzureBridge.Admin.md
@@ -1,16 +1,16 @@
 ---
-Module Name: Azs.Azurebridge.Admin
+Module Name: Azs.AzureBridge.Admin
 Module Guid: 82d2260a-95ae-44bb-af8b-afd67d38f6db
 Download Help Link: {{Please enter FwLink manually}}
 Help Version: {{Please enter version of help manually (X.X.X.X) format}}
 Locale: en-US
 ---
 
-# Azs.Azurebridge.Admin Module
+# Azs.AzureBridge.Admin Module
 ## Description
 Preview release of the AzureStack AzureBridge administrator module which allows you to manage your AzureStack marketplace items. 
 
-## Azs.Azurebridge.Admin Cmdlets
+## Azs.AzureBridge.Admin Cmdlets
 ### [Get-AzsAzureBridgeActivation](Get-AzsAzureBridgeActivation.md)
 Returns the Azure Bridge Activation.
 

--- a/azurestackps-1.8.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-1.8.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.8.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-1.8.2/Azs.Azurebridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.2/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.8.2/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-1.8.2/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-1.8.2/Azs.Azurebridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,6 +1,6 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
-Module Name: Azs.Azurebridge.Admin
+external help file: Azs.AzureBridge.Admin-help.xml
+Module Name: Azs.AzureBridge.Admin
 online version:
 schema: 2.0.0
 ---

--- a/azurestackps-2.0.0/Azs.AzureBridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-2.0.0/Azs.AzureBridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.0/Azs.AzureBridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-2.0.0/Azs.AzureBridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.0/Azs.AzureBridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-2.0.0/Azs.AzureBridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.0/Azs.AzureBridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-2.0.0/Azs.AzureBridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.0/Azs.AzureBridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-2.0.0/Azs.AzureBridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.1/Azs.AzureBridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-2.0.1/Azs.AzureBridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.1/Azs.AzureBridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-2.0.1/Azs.AzureBridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.1/Azs.AzureBridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-2.0.1/Azs.AzureBridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.1/Azs.AzureBridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-2.0.1/Azs.AzureBridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.1/Azs.AzureBridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-2.0.1/Azs.AzureBridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.2/Azs.AzureBridge.Admin/Get-AzsAzureBridgeActivation.md
+++ b/azurestackps-2.0.2/Azs.AzureBridge.Admin/Get-AzsAzureBridgeActivation.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.2/Azs.AzureBridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-2.0.2/Azs.AzureBridge.Admin/Get-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.2/Azs.AzureBridge.Admin/Get-AzsAzureBridgeProduct.md
+++ b/azurestackps-2.0.2/Azs.AzureBridge.Admin/Get-AzsAzureBridgeProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.2/Azs.AzureBridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-2.0.2/Azs.AzureBridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0

--- a/azurestackps-2.0.2/Azs.AzureBridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
+++ b/azurestackps-2.0.2/Azs.AzureBridge.Admin/Remove-AzsAzureBridgeDownloadedProduct.md
@@ -1,5 +1,5 @@
 ---
-external help file: Azs.Azurebridge.Admin-help.xml
+external help file: Azs.AzureBridge.Admin-help.xml
 Module Name: Azs.AzureBridge.Admin
 online version: 
 schema: 2.0.0


### PR DESCRIPTION
Module names has changed from `Azs.Azure**b**ridge.xx` to `Azs.Azure**B**ridge.xx` under azurestakps from 1.x.x to 2.x.x versions. I guess it is a content issue. Create a pr to fix.