### PR TITLE
update missing descriptions

### DIFF
--- a/docs-conceptual/azurermps-4.4.1/get-started-azureps.md
+++ b/docs-conceptual/azurermps-4.4.1/get-started-azureps.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with Azure PowerShell | Microsoft Docs
-description:
+description: "Learn more about: Getting started with Azure PowerShell"
 ms.devlang: powershell
 ms.topic: conceptual
 ms.date: 11/15/2017

--- a/docs-conceptual/azurermps-5.7.0/get-started-azureps.md
+++ b/docs-conceptual/azurermps-5.7.0/get-started-azureps.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with Azure PowerShell
-description:
+description: "Learn more about: Get started with Azure PowerShell"
 ms.devlang: powershell
 ms.topic: conceptual
 ms.date: 11/15/2017

--- a/docs-conceptual/azurermps-6.13.0/get-started-azureps.md
+++ b/docs-conceptual/azurermps-6.13.0/get-started-azureps.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with Azure PowerShell
-description:
+description: "Learn more about: Get started with Azure PowerShell"
 ms.devlang: powershell
 ms.topic: conceptual
 ms.date: 09/11/2018


### PR DESCRIPTION
@MightyPen @mikefrobbins OK, this is just the items in docs_conceptual. Which means I'm still unclear as to why there's that discrepancy between Kusto (reports 306 missing descriptions) and this (three). It could be that it's picking up some of the reference content, but it would be nice to drill down into that report (which doesn't seem possible). Either way, I did a manual sweep of the conceptual docs, and these do seem to be the only pages missing description metadata.