### PR TITLE
Included Visual Studio PowerShell conflict

### DIFF
--- a/docs-conceptual/azps-6.3.0/install-az-ps.md
+++ b/docs-conceptual/azps-6.3.0/install-az-ps.md
@@ -3,7 +3,7 @@ title: Install the Azure Az PowerShell module with PowerShellGet
 description: How to install the Azure Az PowerShell with PowerShellGet
 ms.devlang: powershell
 ms.topic: conceptual
-ms.date: 06/30/2021
+ms.date: 08/10/2021
 ms.custom: devx-track-azurepowershell
 ms.service: azure-powershell
 ---
@@ -27,7 +27,7 @@ Az PowerShell modules, and makes their cmdlets available for use.
 > PowerShell module on all platforms.
 
  The Azure Az PowerShell module works with PowerShell 7.x and later on all platforms. Azure
- PowerShell has no additional requirements when run on PowerShell 7.x and later (for conflicts caused by an earlier AzureRM installation or Developer PowerShell for Visual Studio, see [Troubleshooting](install-az-ps.md#troubleshooting) below).
+ PowerShell has no additional requirements when run on PowerShell 7.x and later.
 
 - Install the
  [latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
@@ -39,8 +39,10 @@ To check your PowerShell version, run the following command from within a PowerS
 $PSVersionTable.PSVersion
 ```
 
-PowerShell script execution policy must be set to remote signed or less restrictive. `Get-ExecutionPolicy -List`
-can be used to determine the current execution policy. For more information, see [about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+PowerShell script execution policy must be set to remote signed or less restrictive.
+`Get-ExecutionPolicy -List` can be used to determine the current execution policy. For more
+information, see
+[about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
 
 ```powershell-interactive
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
@@ -132,9 +134,14 @@ In a scenario where you want to install both AzureRM and the Az PowerShell modul
 system, AzureRM must be installed only in the user scope for Windows PowerShell. Install the Az
 PowerShell module for PowerShell 7.x on the same system.
 
-Older versions of Visual Studio may install Azure PowerShell as part of the Azure development workload, which installs the AzureRM module.  Azure PowerShell can be removed using the Visual Studio installer or by using "Uninstall" in Apps & features.  If you have already installed PowerShell 7.x, you may need to [manually install](install-az-ps.md#installation) the Azure Az PowerShell module.
-
 [!INCLUDE [migrate-to-az-banner](../../includes/migrate-to-az-banner.md)]
+
+#### Visual Studio
+
+Older versions of Visual Studio may install Azure PowerShell as part of the Azure development
+workload, which installs the AzureRM module. Azure PowerShell can be removed using the Visual Studio
+installer or by using "Uninstall" in Apps & features. If you have already installed PowerShell 7.x,
+you may need to [manually install](install-az-ps.md#installation) the Azure Az PowerShell module.
 
 ### Proxy blocks connection
 

--- a/docs-conceptual/azps-6.3.0/install-az-ps.md
+++ b/docs-conceptual/azps-6.3.0/install-az-ps.md
@@ -27,7 +27,7 @@ Az PowerShell modules, and makes their cmdlets available for use.
 > PowerShell module on all platforms.
 
  The Azure Az PowerShell module works with PowerShell 7.x and later on all platforms. Azure
- PowerShell has no additional requirements when run on PowerShell 7.x and later (for conflicts caused by an earlier AzureRM installation or Developer PowerShell for Visual Studio, see [Troubleshooting](install-az-ps.md#Troubleshooting) below).
+ PowerShell has no additional requirements when run on PowerShell 7.x and later (for conflicts caused by an earlier AzureRM installation or Developer PowerShell for Visual Studio, see [Troubleshooting](install-az-ps.md#troubleshooting) below).
 
 - Install the
  [latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
@@ -132,7 +132,7 @@ In a scenario where you want to install both AzureRM and the Az PowerShell modul
 system, AzureRM must be installed only in the user scope for Windows PowerShell. Install the Az
 PowerShell module for PowerShell 7.x on the same system.
 
-Older versions of Visual Studio may install Azure PowerShell as part of the Azure development workload, which installs the AzureRM module.  Azure PowerShell can be removed using the Visual Studio installer or by using "Uninstall" in Apps & features.  If you have already installed PowerShell 7.x, you may need to [manually install](install-az-ps.md#Installation) the Azure Az PowerShell module.
+Older versions of Visual Studio may install Azure PowerShell as part of the Azure development workload, which installs the AzureRM module.  Azure PowerShell can be removed using the Visual Studio installer or by using "Uninstall" in Apps & features.  If you have already installed PowerShell 7.x, you may need to [manually install](install-az-ps.md#installation) the Azure Az PowerShell module.
 
 [!INCLUDE [migrate-to-az-banner](../../includes/migrate-to-az-banner.md)]
 

--- a/docs-conceptual/azps-6.3.0/install-az-ps.md
+++ b/docs-conceptual/azps-6.3.0/install-az-ps.md
@@ -27,7 +27,7 @@ Az PowerShell modules, and makes their cmdlets available for use.
 > PowerShell module on all platforms.
 
  The Azure Az PowerShell module works with PowerShell 7.x and later on all platforms. Azure
- PowerShell has no additional requirements when run on PowerShell 7.x and later.
+ PowerShell has no additional requirements when run on PowerShell 7.x and later (for conflicts caused by an earlier AzureRM installation or Developer PowerShell for Visual Studio, see [Troubleshooting](install-az-ps.md#Troubleshooting) below).
 
 - Install the
  [latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
@@ -131,6 +131,8 @@ a problem not listed here,
 In a scenario where you want to install both AzureRM and the Az PowerShell module on the same
 system, AzureRM must be installed only in the user scope for Windows PowerShell. Install the Az
 PowerShell module for PowerShell 7.x on the same system.
+
+Older versions of Visual Studio may install Azure PowerShell as part of the Azure development workload, which installs the AzureRM module.  Azure PowerShell can be removed using the Visual Studio installer or by using "Uninstall" in Apps & features.  If you have already installed PowerShell 7.x, you may need to [manually install](install-az-ps.md#Installation) the Azure Az PowerShell module.
 
 [!INCLUDE [migrate-to-az-banner](../../includes/migrate-to-az-banner.md)]
 


### PR DESCRIPTION
There is a conflict that prevents PowerShell 7.x from successfully executing Az module commands if an older version of Visual Studio with Azure PowerShell or the Azure development workload has been installed as this includes the AzureRM module.  This PR draws attention to the possibility of the Visual Studio conflict and provides troubleshooting steps.  This resolves https://github.com/MicrosoftDocs/azure-docs-powershell/issues/1855.