### PR TITLE
Fix typo in cmdlet example

### DIFF
--- a/azps-5.9.0/Az.ApiManagement/Remove-AzApiManagementApiSchema.md
+++ b/azps-5.9.0/Az.ApiManagement/Remove-AzApiManagementApiSchema.md
@@ -40,7 +40,7 @@ The cmdlet **Remove-AzApiManagementSchema** from the Api.
 ### Example 1: Removes the Api Schema from the API
 ```powershell
 PS C:\>$apimContext = New-AzApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzAzureRmApiManagementApiSchema -Context $apimContext -ApiId "echo-api" -SchemaId "2"
+PS C:\>Remove-AzApiManagementApiSchema -Context $apimContext -ApiId "echo-api" -SchemaId "2"
 ```
 
 The script removes the Schema `2` from the Api `echo-api` if it is not referenced.

--- a/azps-6.2.1/Az.ApiManagement/Remove-AzApiManagementApiSchema.md
+++ b/azps-6.2.1/Az.ApiManagement/Remove-AzApiManagementApiSchema.md
@@ -40,7 +40,7 @@ The cmdlet **Remove-AzApiManagementSchema** from the Api.
 ### Example 1: Removes the Api Schema from the API
 ```powershell
 PS C:\>$apimContext = New-AzApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzAzureRmApiManagementApiSchema -Context $apimContext -ApiId "echo-api" -SchemaId "2"
+PS C:\>Remove-AzApiManagementApiSchema -Context $apimContext -ApiId "echo-api" -SchemaId "2"
 ```
 
 The script removes the Schema `2` from the Api `echo-api` if it is not referenced.

--- a/azps-6.3.0/Az.ApiManagement/Remove-AzApiManagementApiSchema.md
+++ b/azps-6.3.0/Az.ApiManagement/Remove-AzApiManagementApiSchema.md
@@ -40,7 +40,7 @@ The cmdlet **Remove-AzApiManagementSchema** from the Api.
 ### Example 1: Removes the Api Schema from the API
 ```powershell
 PS C:\>$apimContext = New-AzApiManagementContext -ResourceGroupName "Api-Default-WestUS" -ServiceName "contoso"
-PS C:\>Remove-AzAzureRmApiManagementApiSchema -Context $apimContext -ApiId "echo-api" -SchemaId "2"
+PS C:\>Remove-AzApiManagementApiSchema -Context $apimContext -ApiId "echo-api" -SchemaId "2"
 ```
 
 The script removes the Schema `2` from the Api `echo-api` if it is not referenced.


### PR DESCRIPTION
Example 1 has a wrong cmdlet in line 2, the cmdlet specified doesn't exist because of a typo, happening in all versions.