### PR TITLE
revert change detection docs to remove full share verbiage

### DIFF
--- a/azps-6.4.0/Az.StorageSync/Invoke-AzStorageSyncChangeDetection.md
+++ b/azps-6.4.0/Az.StorageSync/Invoke-AzStorageSyncChangeDetection.md
@@ -10,15 +10,15 @@ original_content_git_url: https://github.com/Azure/azure-powershell/blob/main/sr
 # Invoke-AzStorageSyncChangeDetection
 
 ## SYNOPSIS
-This command can be used to manually initiate the detection of namespace changes. It can be targeted to the entire share, subfolder or set of files. When running the command with the -DirectoryPath or -Path parameters, a maximum of 10,000 items can be detected. If the scope of changes is known to you, limit the execution of this command to parts of the namespace, so change detection can finish quickly and within the 10,000 item limit. Alternatively, you can avoid the item limit by running the cmdlet without these parameters, invoking share-level change detection. 
+This command can be used to manually initiate the detection of namespaces changes. It can be targeted to the entire share, subfolder or set of files. A maximum of 10,000 items can be detected. If the scope of changes is known to you, limit the execution of this command to parts of the namespace, so change detection can finish quickly and within the 10,000 item limit.
 
 > [!Note]  
-> If run with -DirectoryPath or -Path parameters, the command will not detect the following changes in the Azure file share:
+> The Invoke-AzStorageSyncChangeDetection cmdlet will not detect the following changes in the Azure file share:
 > - Files that are deleted. 
 > - Files that are moved out of the share.
 > - Files that are deleted and created with the same name.  
 > 
->  If share-level change detection is invoked, all of these changes will be detected. These changes will also be detected when the scheduled [change detection job](https://docs.microsoft.com/azure/storage/files/storage-sync-files-troubleshoot?tabs=portal1%2Cazure-portal#afs-change-detection) runs.
+>  These changes will be detected when the [change detection job](https://docs.microsoft.com/azure/storage/files/storage-sync-files-troubleshoot?tabs=portal1%2Cazure-portal#afs-change-detection) runs.
 
 ## SYNTAX
 
@@ -36,13 +36,6 @@ Invoke-AzStorageSyncChangeDetection [-ResourceGroupName] <String> [-StorageSyncS
  [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### FullShareStringParameterSet
-```
-Invoke-AzStorageSyncChangeDetection [-ResourceGroupName] <String> [-StorageSyncServiceName] <String>
- [-SyncGroupName] <String> -Name <String> [-PassThru] [-AsJob] [-DefaultProfile <IAzureContextContainer>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ### ResourceIdAndDirectoryParameterSet
 ```
 Invoke-AzStorageSyncChangeDetection [-ResourceId] <String> -DirectoryPath <String> [-Recursive] [-PassThru]
@@ -52,12 +45,6 @@ Invoke-AzStorageSyncChangeDetection [-ResourceId] <String> -DirectoryPath <Strin
 ### ResourceIdAndPathParameterSet
 ```
 Invoke-AzStorageSyncChangeDetection [-ResourceId] <String> -Path <String[]> [-PassThru] [-AsJob]
- [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### FullShareResourceIdParameterSet
-```
-Invoke-AzStorageSyncChangeDetection [-ResourceId] <String> [-PassThru] [-AsJob]
  [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -73,14 +60,8 @@ Invoke-AzStorageSyncChangeDetection [-InputObject] <PSCloudEndpoint> -Path <Stri
  [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### FullShareObjectParameterSet
-```
-Invoke-AzStorageSyncChangeDetection [-InputObject] <PSCloudEndpoint> [-PassThru] [-AsJob]
- [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
 ## DESCRIPTION
-Periodically, Azure File Sync checks the namespace inside a syncing Azure file share for changes that came into the file share by other means than sync. The goal is to identify these changes and ultimately sync them to connected servers. This command can be used to manually initiate the detection of namespaces changes. It can be targeted to the entire share, subfolder or set of files. If the scope of changes is known to you, limit the execution of this command to parts of the namespace, so individual item change detection can finish quickly and within the 10,000 items limit. Otherwise, run the command without the -DirectoryPath or -Path parameters to invoke full share-level change detection.
+Periodically, Azure File Sync checks the namespace inside a syncing Azure file share for changes that came into the file share by other means than sync. The goal is to identify these changes and ultimately sync them to connected servers. This command can be used to manually initiate the detection of namespaces changes. It can be targeted to the entire share, subfolder or set of files. If the scope of changes is known to you, limit the execution of this command to parts of the namespace, so change detection can finish quickly and within the 10,000 items limit.
 
 ## EXAMPLES
 
@@ -105,13 +86,6 @@ PS C:\> Invoke-AzStorageSyncChangeDetection -ResourceGroupName "myResourceGroup"
 
 In this example, change detection is run for the "Examples" directory and will recursively detect changes in subdirectories. 
 Keep in mind the cmdlet will fail if the path contains more than 10,000 items. If the path contains more than 10,000 items, run the command on sub-parts of the namespace.
-
-### Example 4
-```powershell
-PS C:\> Invoke-AzStorageSyncChangeDetection -ResourceGroupName "myResourceGroup" -StorageSyncServiceName "myStorageSyncServiceName" -SyncGroupName "mySyncGroupName" -CloudEndpointName "b38fc242-8100-4807-89d0-399cef5863bf"
-```
-
-In this example, neither -DirectoryPath nor -Path has been passed to the command. This will invoke change detection on the entire file share.
 
 ## PARAMETERS
 
@@ -165,7 +139,7 @@ CloudEndpoint Object, normally passed through the parameter.
 
 ```yaml
 Type: Microsoft.Azure.Commands.StorageSync.Models.PSCloudEndpoint
-Parameter Sets: ObjectAndDirectoryParameterSet, ObjectAndPathParameterSet, FullShareObjectParameterSet
+Parameter Sets: ObjectAndDirectoryParameterSet, ObjectAndPathParameterSet
 Aliases: CloudEndpoint
 
 Required: True
@@ -180,7 +154,7 @@ Name of the CloudEndpoint. The name is a GUID, not the friendly name that's disp
 
 ```yaml
 Type: System.String
-Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet, FullShareStringParameterSet
+Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet
 Aliases: CloudEndpointName
 
 Required: True
@@ -240,7 +214,7 @@ Resource Group Name.
 
 ```yaml
 Type: System.String
-Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet, FullShareStringParameterSet
+Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet
 Aliases:
 
 Required: True
@@ -255,7 +229,7 @@ CloudEndpoint Resource Id
 
 ```yaml
 Type: System.String
-Parameter Sets: ResourceIdAndDirectoryParameterSet, ResourceIdAndPathParameterSet, FullShareResourceIdParameterSet
+Parameter Sets: ResourceIdAndDirectoryParameterSet, ResourceIdAndPathParameterSet
 Aliases: CloudEndpointId
 
 Required: True
@@ -270,7 +244,7 @@ Name of the StorageSyncService.
 
 ```yaml
 Type: System.String
-Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet, FullShareStringParameterSet
+Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet
 Aliases: ParentName
 
 Required: True
@@ -285,7 +259,7 @@ Name of the SyncGroup.
 
 ```yaml
 Type: System.String
-Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet, FullShareStringParameterSet
+Parameter Sets: StringAndDirectoryParameterSet, StringAndPathParameterSet
 Aliases:
 
 Required: True
@@ -327,7 +301,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
This change temporarily hides mentions of full share change detection from the change detection cmdlet documentation while the feature is yet to be introduced in the service. Once the service change is deployed into prod, this documentation change will be reverted once again.