### PR TITLE
docs: add link to azad migration guide

### DIFF
--- a/docs-conceptual/azps-7.0.0/migrate-az-7.0.0.md
+++ b/docs-conceptual/azps-7.0.0/migrate-az-7.0.0.md
@@ -409,7 +409,7 @@ Get-AzRecoveryServicesBackupJob -BackupManagementType MAB -VaultId $vault.ID
 ## Az.Resources
 
 ### `AzAD cmdlets`
-Please refer to the [migration guide](https://docs.microsoft.com/powershell/azure/azps-msgraph-migration-changes) of the Active Directory cmdlets.
+Please refer to the [migration guide](/powershell/azure/azps-msgraph-migration-changes) of the Active Directory cmdlets.
 
 ### `PolicyAssignment cmdlets`
 The type of property 'Identity' of type 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyAssignment' has changed from 'System.Management.Automation.PSObject' to 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyIdentity'.

--- a/docs-conceptual/azps-7.0.0/migrate-az-7.0.0.md
+++ b/docs-conceptual/azps-7.0.0/migrate-az-7.0.0.md
@@ -409,7 +409,7 @@ Get-AzRecoveryServicesBackupJob -BackupManagementType MAB -VaultId $vault.ID
 ## Az.Resources
 
 ### `AzAD cmdlets`
-Please refer to the [migration guide](https://docs.microsoft.com/en-us/powershell/azure/azps-msgraph-migration-changes?view=azps-7.0.0) of the Active Directory cmdlets.
+Please refer to the [migration guide](https://docs.microsoft.com/powershell/azure/azps-msgraph-migration-changes) of the Active Directory cmdlets.
 
 ### `PolicyAssignment cmdlets`
 The type of property 'Identity' of type 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyAssignment' has changed from 'System.Management.Automation.PSObject' to 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyIdentity'.

--- a/docs-conceptual/azps-7.0.0/migrate-az-7.0.0.md
+++ b/docs-conceptual/azps-7.0.0/migrate-az-7.0.0.md
@@ -409,7 +409,7 @@ Get-AzRecoveryServicesBackupJob -BackupManagementType MAB -VaultId $vault.ID
 ## Az.Resources
 
 ### `AzAD cmdlets`
-Please refer to (placeholder) for the migration guide of Active Directory cmdlets.
+Please refer to the [migration guide](https://docs.microsoft.com/en-us/powershell/azure/azps-msgraph-migration-changes?view=azps-7.0.0) of the Active Directory cmdlets.
 
 ### `PolicyAssignment cmdlets`
 The type of property 'Identity' of type 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyAssignment' has changed from 'System.Management.Automation.PSObject' to 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyIdentity'.


### PR DESCRIPTION
Replaces placeholder with link to the migration guide.