### PR TITLE
Remove-Extra-Word

### DIFF
--- a/azuresmps-4.0.0/Azure.Service/New-AzureQuickVM.md
+++ b/azuresmps-4.0.0/Azure.Service/New-AzureQuickVM.md
@@ -54,7 +54,7 @@ The cmdlet bases the virtual machine on the specified image.
 The command specifies the *WaitForBoot* parameter.
 Therefore, the cmdlet waits for the virtual machine to start.
 
-### Example 2: Create a virtual machine that by using certificates
+### Example 2: Create a virtual machine by using certificates
 ```
 PS C:\> $certs = Get-ChildItem Cert:\CurrentUser\My
 PS C:\> New-AzureQuickVM -Windows -ServiceName "MySvc1" -name "MyWinVM1" -ImageName "Image07" -Password "password" -AdminUserName "AdminMain" -WinRMCertificate $certs[0] -X509Certificates $certs[1], $certs[2] -WaitForBoot


### PR DESCRIPTION
There is an extra word in the Example 2 header. 

It currently reads: ``` Create a virtual machine that by using certificates ``` 
It should read: ```Create a virtual machine by using certificates ```
