### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3197,57 +3197,57 @@
     },
     {
       "source_path": "docs-conceptual/azuredmps-0.9.0/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azuresmps-4.0.0/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-1.5.0/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-1.6.0/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-1.7.2/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-1.8.0/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-1.8.1/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-1.8.2/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-2.0.0/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-2.0.1/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     },
     {
       "source_path": "docs-conceptual/azurestackps-2.0.2/index.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/azure/overview",
+      "redirect_url": "/powershell/azure/overview",
       "redirect_document_id": false
     }
   ]


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Content & Learning team is fixing build validation errors on docs.microsoft.com for the rest of H2. This will eliminate potential accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only build validation fixes and does not change other content.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: @MonicaRush
