### PR TITLE
Fixes 2387 - Removed dash from param name in hash table

### DIFF
--- a/docs-conceptual/azps-8.3.0/manage-azure-resources-invoke-azrestmethod.md
+++ b/docs-conceptual/azps-8.3.0/manage-azure-resources-invoke-azrestmethod.md
@@ -1,7 +1,7 @@
 ---
 description: How to use Azure PowerShell to manage resources with the Invoke-AzRestMethod cmdlet.
 ms.custom: devx-track-azurepowershell
-ms.date: 09/06/2022
+ms.date: 11/28/2022
 ms.devlang: powershell
 ms.service: azure-powershell
 ms.topic: conceptual
@@ -109,7 +109,7 @@ $specificIpParams = @{
          } ]
       }
   } }'
-  -Method = 'PATCH'
+  Method = 'PATCH'
 }
 Invoke-AzRestMethod @specificIpParams
 ```

--- a/docs-conceptual/azps-9.0.1/manage-azure-resources-invoke-azrestmethod.md
+++ b/docs-conceptual/azps-9.0.1/manage-azure-resources-invoke-azrestmethod.md
@@ -1,7 +1,7 @@
 ---
 description: How to use Azure PowerShell to manage resources with the Invoke-AzRestMethod cmdlet.
 ms.custom: devx-track-azurepowershell
-ms.date: 10/18/2022
+ms.date: 11/28/2022
 ms.devlang: powershell
 ms.service: azure-powershell
 ms.topic: conceptual
@@ -109,7 +109,7 @@ $specificIpParams = @{
          } ]
       }
   } }'
-  -Method = 'PATCH'
+  Method = 'PATCH'
 }
 Invoke-AzRestMethod @specificIpParams
 ```

--- a/docs-conceptual/azps-9.1.0/manage-azure-resources-invoke-azrestmethod.md
+++ b/docs-conceptual/azps-9.1.0/manage-azure-resources-invoke-azrestmethod.md
@@ -1,7 +1,7 @@
 ---
 description: How to use Azure PowerShell to manage resources with the Invoke-AzRestMethod cmdlet.
 ms.custom: devx-track-azurepowershell
-ms.date: 11/01/2022
+ms.date: 11/28/2022
 ms.devlang: powershell
 ms.service: azure-powershell
 ms.topic: conceptual
@@ -109,7 +109,7 @@ $specificIpParams = @{
          } ]
       }
   } }'
-  -Method = 'PATCH'
+  Method = 'PATCH'
 }
 Invoke-AzRestMethod @specificIpParams
 ```


### PR DESCRIPTION
# PR Summary

Fixes #2387 - Removed dash from param name in hash table used for splatting.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
