### PR TITLE
Fix links to PSGallery docs

### DIFF
--- a/docs-conceptual/azps-0.10.0/install-az-ps.md
+++ b/docs-conceptual/azps-0.10.0/install-az-ps.md
@@ -3,26 +3,25 @@ title: Install Azure PowerShell with PowerShellGet
 description: How to install Azure PowerShell with PowerShellGet
 ms.devlang: powershell
 ms.topic: conceptual
-ms.date: 02/26/2020 
-ms.custom: devx-track-azurepowershell 
+ms.date: 02/26/2020
+ms.custom: devx-track-azurepowershell
 ms.service: azure-powershell
 ---
 
 # Install Azure PowerShell
 
 This article explains how to install the Azure PowerShell modules using
-[PowerShellGet](/powershell/scripting/gallery/installing-psget). These instructions work on Windows,
+[PowerShellGet][01]. These instructions work on Windows,
 macOS, and Linux platforms.
 
-Azure PowerShell is also available in Azure [Cloud Shell](/azure/cloud-shell/overview).
+Azure PowerShell is also available in Azure [Cloud Shell][02].
 
 ## Requirements
 
 Azure PowerShell works with PowerShell 5.1 or higher on Windows, or PowerShell Core 6.x and later on
-all platforms. You should install the
-[latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
-your operating system. Azure PowerShell has no additional requirements when run on PowerShell 6.2.4
-and later.
+all platforms. You should install the [latest version of PowerShell][03] available for your
+operating system. Azure PowerShell has no additional requirements when run on PowerShell 6.2.4 and
+later.
 
 To check your PowerShell version, run the command:
 
@@ -32,11 +31,11 @@ $PSVersionTable.PSVersion
 
 To use Azure PowerShell in PowerShell 5.1 on Windows:
 
-1. Update to
-   [Windows PowerShell 5.1](/powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell).
-   If you're on Windows 10 version 1607 or higher, you already have PowerShell 5.1 installed.
-2. Install [.NET Framework 4.7.2 or later](/dotnet/framework/install).
-3. Make sure you have the latest version of PowerShellGet. Run `Install-Module -Name PowerShellGet -Force`.
+1. Update to [Windows PowerShell 5.1][04]. If you're on Windows 10 version 1607 or higher, you
+   already have PowerShell 5.1 installed.
+2. Install [.NET Framework 4.7.2 or later][05].
+3. Make sure you have the latest version of PowerShellGet. Run
+   `Install-Module -Name PowerShellGet -Force`.
 
 ## Install the Azure PowerShell module
 
@@ -68,7 +67,7 @@ You are installing the modules from an untrusted repository. If you trust this r
 its InstallationPolicy value by running the `Set-PSRepository` cmdlet.
 
 Are you sure you want to install the modules from 'PSGallery'?
-[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"):
+[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"):
 ```
 
 Answer `Yes` or `Yes to All` to continue with the installation.
@@ -96,13 +95,12 @@ you can still install offline using one of these methods:
 * Download the modules to another location in your network and use that as an installation source.
   This method allows you to cache PowerShell modules on a single server or file share to be deployed
   with PowerShellGet to any disconnected systems. Learn how to set up a local repository and install
-  on disconnected systems with
-  [Working with local PowerShellGet repositories](/powershell/scripting/gallery/how-to/working-with-local-psrepositories).
-* [Download the Azure PowerShell MSI](install-az-ps-msi.md) to a machine connected to the network,
-  and then copy the installer to systems without access to PowerShell Gallery. Keep in mind that the
-  MSI installer only works for PowerShell 5.1 on Windows.
-* Save the module with [Save-Module](/powershell/module/PowershellGet/Save-Module) to a file share,
-  or save it to another source and manually copy it to other machines:
+  on disconnected systems with [Working with local PowerShellGet repositories][06].
+* [Download the Azure PowerShell MSI][07] to a machine connected to the network, and then copy the
+  installer to systems without access to PowerShell Gallery. Keep in mind that the MSI installer
+  only works for PowerShell 5.1 on Windows.
+* Save the module with [Save-Module][08] to a file share, or save it to another source and manually
+  copy it to other machines:
 
   ```powershell-interactive
   Save-Module -Name Az -Path '\\server\share\PowerShell\modules' -Force
@@ -111,7 +109,7 @@ you can still install offline using one of these methods:
 ## Troubleshooting
 
 Here are some common problems seen when installing the Azure PowerShell module. If you experience a
-problem not listed here, [file an issue on GitHub](https://github.com/azure/azure-powershell/issues).
+problem not listed here, [file an issue on GitHub][09].
 
 ### Proxy blocks connection
 
@@ -130,7 +128,7 @@ $webClient.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCrede
 
 If your operating system credentials are configured correctly, this configuration routes PowerShell
 requests through the proxy. To have this setting persist between sessions, add the commands to your
-[PowerShell profile](/powershell/module/microsoft.powershell.core/about/about_profiles).
+[PowerShell profile][10].
 
 To install the package, your proxy needs to allow HTTPS connections to the following address:
 
@@ -151,14 +149,14 @@ Connect-AzAccount
 
 You'll need to repeat these steps for every new PowerShell session you start. To learn how to
 persist your Azure sign in across PowerShell sessions, see
-[Persist user credentials across PowerShell sessions](context-persistence.md).
+[Persist user credentials across PowerShell sessions][11].
 
 ## Update the Azure PowerShell module
 
 To update any PowerShell module, you should use the same method used to install the module. For
-example, if you originally used `Install-Module`, then you should use
-[Update-Module](/powershell/module/powershellget/update-module) to get the latest version. If you
-originally used the MSI package then you should download and install the new MSI package.
+example, if you originally used `Install-Module`, then you should use [Update-Module][12] to get the
+latest version. If you originally used the MSI package then you should download and install the new
+MSI package.
 
 The PowerShellGet cmdlets cannot update modules that were installed from an MSI package. MSI
 packages do not update modules that were installed using PowerShellGet. If you have any issues
@@ -176,8 +174,8 @@ if (Get-Module -Name AzureRM -ListAvailable) {
 
 Unlike MSI-based installations, installing or updating using PowerShellGet does not remove older
 versions that may exist on your system. To remove old versions of Azure PowerShell from your system,
-see [Uninstall the Azure PowerShell module](uninstall-az-ps.md). For more information about
-MSI-based installations, see [Install Azure PowerShell with an MSI](install-az-ps-msi.md).
+see [Uninstall the Azure PowerShell module][13]. For more information about MSI-based installations,
+see [Install Azure PowerShell with an MSI][14].
 
 ## Use multiple versions of Azure PowerShell
 
@@ -188,7 +186,7 @@ versions of Azure PowerShell installed, use the following command:
 Get-InstalledModule -Name Az -AllVersions | Select-Object -Property Name, Version
 ```
 
-To remove a version of Azure PowerShell, see [Uninstall the Azure PowerShell module](uninstall-az-ps.md).
+To remove a version of Azure PowerShell, see [Uninstall the Azure PowerShell module][13].
 
 If you have more than one version of the module installed, module autoload and `Import-Module` load
 the latest version by default.
@@ -205,13 +203,30 @@ Import-Module -Name Az -RequiredVersion 3.6.1
 
 ## Provide feedback
 
-If you find a bug in Azure PowerShell,
-[file an issue on GitHub](https://github.com/Azure/azure-powershell/issues). To provide feedback
-from the command line, use the [Send-Feedback](/powershell/module/az.accounts/send-feedback) cmdlet.
+If you find a bug in Azure PowerShell, [file an issue on GitHub][09]. To provide feedback from the
+command line, use the [Send-Feedback][17] cmdlet.
 
 ## Next Steps
 
 To learn more about the Azure PowerShell modules and their features, see
-[Get Started with Azure PowerShell](get-started-azureps.md). If you're familiar with Azure
-PowerShell and need to migrate from AzureRM, see
-[Migrate from AzureRM to Az](migrate-from-azurerm-to-az.md).
+[Get Started with Azure PowerShell][18]. If you're familiar with Azure PowerShell and need to
+migrate from AzureRM, see [Migrate from AzureRM to Az][19].
+
+<!-- link references -->
+[01]: /powershell/gallery/powershellget/install-powershellget
+[02]: /azure/cloud-shell/overview
+[03]: /powershell/scripting/install/installing-powershell
+[04]: /powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell
+[05]: /dotnet/framework/install
+[06]: /powershell/gallery/how-to/working-with-local-psrepositories
+[07]: install-az-ps-msi.md
+[08]: /powershell/module/PowershellGet/Save-Module
+[09]: https://github.com/azure/azure-powershell/issues
+[10]: /powershell/module/microsoft.powershell.core/about/about_profiles
+[11]: context-persistence.md
+[12]: /powershell/module/powershellget/update-module
+[13]: uninstall-az-ps.md
+[14]: install-az-ps-msi.md
+[17]: /powershell/module/az.accounts/send-feedback
+[18]: get-started-azureps.md
+[19]: migrate-from-azurerm-to-az.md

--- a/docs-conceptual/azps-8.3.0/install-az-ps.md
+++ b/docs-conceptual/azps-8.3.0/install-az-ps.md
@@ -11,11 +11,10 @@ title: Install the Azure Az PowerShell module
 # Install the Azure Az PowerShell module
 
 This article explains how to install the Azure Az PowerShell module from
-[The PowerShell Gallery](/powershell/scripting/gallery/overview). These instructions work on
-Windows, Linux, and macOS platforms.
+[The PowerShell Gallery][01]. These instructions work on Windows, Linux, and macOS platforms.
 
-The Azure Az PowerShell module is preinstalled in Azure
-[Cloud Shell](/azure/cloud-shell/overview) and in [Docker images](azureps-in-docker.md).
+The Azure Az PowerShell module is preinstalled in Azure [Cloud Shell][02] and in
+[Docker images][03].
 
 The Azure Az PowerShell module is a rollup module. Installing it downloads the generally available
 Az PowerShell modules, and makes their cmdlets available for use.
@@ -29,9 +28,7 @@ Az PowerShell modules, and makes their cmdlets available for use.
 Azure PowerShell has no additional requirements when run on PowerShell 7.0.6 LTS and PowerShell
 7.1.3 or higher.
 
-- Install the
- [latest version of PowerShell](/powershell/scripting/install/installing-powershell) available for
- your operating system.
+- Install the [latest version of PowerShell][04] available for your operating system.
 
 To check your PowerShell version, run the following command from within a PowerShell session:
 
@@ -41,8 +38,7 @@ $PSVersionTable.PSVersion
 
 PowerShell script execution policy must be set to remote signed or less restrictive.
 `Get-ExecutionPolicy -List` can be used to determine the current execution policy. For more
-information, see
-[about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+information, see [about_Execution_Policies][05].
 
 ```powershell
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
@@ -50,10 +46,10 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 ## Installation
 
-Using the [Install-Module](/powershell/module/powershellget/install-module) cmdlet is the preferred
-installation method for the Az PowerShell module. Install the Az module for the current user only.
-This is the recommended installation scope. This method works the same on Windows, Linux, and macOS
-platforms. Run the following command from a PowerShell session:
+Using the [Install-Module][06] cmdlet is the preferred installation method for the Az PowerShell
+module. Install the Az module for the current user only. This is the recommended installation scope.
+This method works the same on Windows, Linux, and macOS platforms. Run the following command from a
+PowerShell session:
 
 ```powershell
 Install-Module -Name Az -Scope CurrentUser -Repository PSGallery -Force
@@ -68,33 +64,31 @@ options if needed.
 ### Installation on Windows PowerShell
 
 > [!IMPORTANT]
-> If you have the AzureRM PowerShell module installed, see
-> [Az and AzureRM coexistence](troubleshooting.md#az-and-azurerm-coexistence)
-> before proceeding.
+> If you have the AzureRM PowerShell module installed, see [Az and AzureRM coexistence][07] before
+> proceeding.
 
 The Azure Az PowerShell module is also supported for use with PowerShell 5.1 on Windows. To use the
 Azure Az PowerShell module in PowerShell 5.1 on Windows:
 
-1. Update to
-   [Windows PowerShell 5.1](/powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell).
-   If you're on Windows 10 version 1607 or higher, you already have PowerShell 5.1 installed.
-1. Install [.NET Framework 4.7.2 or later](/dotnet/framework/install).
-1. Make sure you have the latest version of PowerShellGet. Run `Install-Module -Name PowerShellGet -Force`.
+1. Update to [Windows PowerShell 5.1][08]. If you're on Windows 10 version 1607 or higher, you
+   already have PowerShell 5.1 installed.
+1. Install [.NET Framework 4.7.2 or later][09].
+1. Make sure you have the latest version of PowerShellGet. Run
+   `Install-Module -Name PowerShellGet -Force`.
 
 ### Offline Installation
 
 In some environments, it's not possible to connect to the PowerShell Gallery. In those situations,
 you can install the Az PowerShell module offline using one of these methods:
 
-- [Download the Azure PowerShell MSI](install-az-ps-msi.md). Keep in mind that the MSI installer
-  only works for PowerShell 5.1 on Windows.
+- [Download the Azure PowerShell MSI][10]. Keep in mind that the MSI installer only works for
+  PowerShell 5.1 on Windows.
 - Download the modules to another location in your network and use that as an installation source.
   This method allows you to cache PowerShell modules on a single server or file share to be deployed
   with PowerShellGet to any disconnected systems. Learn how to set up a local repository and install
-  on disconnected systems with
-  [Working with local PowerShellGet repositories](/powershell/scripting/gallery/how-to/working-with-local-psrepositories).
-- Save the module with [Save-Module](/powershell/module/PowershellGet/Save-Module) to a file share,
-  or save it to another source and manually copy it to other machines.
+  on disconnected systems with [Working with local PowerShellGet repositories][11].
+- Save the module with [Save-Module][12] to a file share, or save it to another source and manually
+  copy it to other machines.
 
 ## Sign in
 
@@ -109,9 +103,9 @@ After executing this command, a new browser window pops up and you can log into 
 ## Update the Azure PowerShell module
 
 To update any PowerShell module, you should use the same method used to install the module. For
-example, if you originally used `Install-Module`, then you should use
-[Update-Module](/powershell/module/powershellget/update-module) to get the latest version. If you
-originally used the MSI package, then you should download and install the new MSI package.
+example, if you originally used `Install-Module`, then you should use [Update-Module][13] to get the
+latest version. If you originally used the MSI package, then you should download and install the new
+MSI package.
 
 The PowerShellGet cmdlets cannot update modules that were installed from an MSI package. MSI
 packages do not update modules that were installed using PowerShellGet. If you have any issues
@@ -128,23 +122,42 @@ versions that may exist on your system.
 > PowerShell module that are currently installed.
 
 To remove all versions of the Az PowerShell module from your system, see
-[Uninstall the Azure PowerShell module](uninstall-az-ps.md). For more information about MSI-based
-installations, see [Install Azure PowerShell with an MSI](install-az-ps-msi.md).
+[Uninstall the Azure PowerShell module][14]. For more information about MSI-based installations, see
+[Install Azure PowerShell with an MSI][15].
 
 ## Troubleshooting
 
-[Troubleshoot installation problems with the Azure Az PowerShell module](troubleshooting.md#installation).
+[Troubleshoot installation problems with the Azure Az PowerShell module][16].
 
 ## Provide feedback
 
-If you find a bug in the Azure Az PowerShell module,
-[file an issue on GitHub](https://github.com/Azure/azure-powershell/issues). To provide feedback
-from within a PowerShell session, use the
-[Send-Feedback](/powershell/module/az.accounts/send-feedback) cmdlet.
+If you find a bug in the Azure Az PowerShell module, [file an issue on GitHub][17]. To provide
+feedback from within a PowerShell session, use the [Send-Feedback][18] cmdlet.
 
 ## Next Steps
 
 To learn more about the Azure Az PowerShell modules and their features, see
-[Get Started with Azure PowerShell](get-started-azureps.md). If you're familiar with Azure
-PowerShell and need to migrate from AzureRM, see
-[Migrate from AzureRM to Az](migrate-from-azurerm-to-az.md).
+[Get Started with Azure PowerShell][19]. If you're familiar with Azure PowerShell and need to
+migrate from AzureRM, see [Migrate from AzureRM to Az][20].
+
+<!-- link references -->
+[01]: /powershell/gallery/overview
+[02]: /azure/cloud-shell/overview
+[03]: azureps-in-docker.md
+[04]: /powershell/scripting/install/installing-powershell
+[05]: /powershell/module/microsoft.powershell.core/about/about_execution_policies
+[06]: /powershell/module/powershellget/install-module
+[07]: troubleshooting.md#az-and-azurerm-coexistence
+[08]: /powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell
+[09]: /dotnet/framework/install
+[10]: install-az-ps-msi.md
+[11]: /powershell/gallery/how-to/working-with-local-psrepositories
+[12]: /powershell/module/PowershellGet/Save-Module
+[13]: /powershell/module/powershellget/update-module
+[14]: uninstall-az-ps.md
+[15]: install-az-ps-msi.md
+[16]: troubleshooting.md#installation
+[17]: https://github.com/Azure/azure-powershell/issues
+[18]: /powershell/module/az.accounts/send-feedback
+[19]: get-started-azureps.md
+[20]: migrate-from-azurerm-to-az.md

--- a/docs-conceptual/azps-9.5.0/install-azps-macos.md
+++ b/docs-conceptual/azps-9.5.0/install-azps-macos.md
@@ -11,22 +11,20 @@ title: Install Azure PowerShell on macOS | Microsoft Docs
 # Install Azure PowerShell on macOS
 
 This article explains how to install the Azure PowerShell Az module from
-[the PowerShell Gallery](/powershell/scripting/gallery/overview) on macOS.
+[the PowerShell Gallery][01] on macOS.
 
 The Az PowerShell module is a rollup module. Installing it downloads the generally available Az
 PowerShell modules and makes their cmdlets available for use.
 
 ## Prerequisites
 
-- Install a supported version of
-  [PowerShell version 7 or higher](/powershell/scripting/install/installing-powershell-on-macos)
+- Install a supported version of [PowerShell version 7 or higher][02]
 
 ## Installation
 
 Open the Terminal or other shell host application and run `pwsh` to start PowerShell.
 
-Use the [Install-Module](/powershell/module/powershellget/install-module) cmdlet to install the Az
-PowerShell module:
+Use the [Install-Module][03] cmdlet to install the Az PowerShell module:
 
 ```powershell
 Install-Module -Name Az -Repository PSGallery -Force
@@ -34,7 +32,7 @@ Install-Module -Name Az -Repository PSGallery -Force
 
 ## Update the Azure PowerShell module
 
-Use the [Update-Module](/powershell/module/powershellget/update-module) cmdlet to update to the
+Use the [Update-Module][04] cmdlet to update to the
 latest version of the Az PowerShell module.
 
 ```powershell
@@ -47,7 +45,7 @@ PowerShell module from your system.
 ## Uninstallation
 
 To remove the Az PowerShell module from your system, see
-[Uninstall the Azure PowerShell module](uninstall-az-ps.md).
+[Uninstall the Azure PowerShell module][05].
 
 ## Sign in
 
@@ -61,23 +59,32 @@ Connect-AzAccount
 Use your Azure account login credentials to log into the browser window that opens.
 
 You'll need to repeat this step for every new PowerShell session you start. To learn how to persist
-your Azure sign-in across PowerShell sessions, see
-[Azure PowerShell context objects](/powershell/azure/context-persistence).
+your Azure sign-in across PowerShell sessions, see [Azure PowerShell context objects][06].
 
 ## Troubleshooting
 
 For solutions to common installation issues with the Az PowerShell module, see
-[Troubleshoot installation problems with the Az PowerShell module](troubleshooting.md#installation).
+[Troubleshoot installation problems with the Az PowerShell module][07].
 
 ## Provide feedback
 
-To file an issue about the Az PowerShell module, see:
-[file an issue on GitHub](https://github.com/Azure/azure-powershell/issues).
+To file an issue about the Az PowerShell module, see: [file an issue on GitHub][08].
 
-To provide feedback from within a PowerShell session, use the
-[Send-Feedback](/powershell/module/az.accounts/send-feedback) cmdlet.
+To provide feedback from within a PowerShell session, use the [Send-Feedback][09] cmdlet.
 
 ## Next steps
 
 To learn more about managing your Azure resources with the Az PowerShell module, see
-[Get Started with Azure PowerShell](get-started-azureps.md).
+[Get Started with Azure PowerShell][10].
+
+<!-- link references -->
+[01]: /powershell/gallery/overview
+[02]: /powershell/scripting/install/installing-powershell-on-macos
+[03]: /powershell/module/powershellget/install-module
+[04]: /powershell/module/powershellget/update-module
+[05]: uninstall-az-ps.md
+[06]: /powershell/azure/context-persistence
+[07]: troubleshooting.md#installation
+[08]: https://github.com/Azure/azure-powershell/issues
+[09]: /powershell/module/az.accounts/send-feedback
+[10]: get-started-azureps.md

--- a/docs-conceptual/azps-9.5.0/install-azps-windows.md
+++ b/docs-conceptual/azps-9.5.0/install-azps-windows.md
@@ -23,7 +23,7 @@ The recommended installation method and PowerShell version for the Az PowerShell
 ::: zone pivot="windows-psgallery"
 
 This article explains how to install the Az PowerShell module on Windows from the
-[PowerShell Gallery](/powershell/scripting/gallery/overview).
+[PowerShell Gallery][01].
 
 ## Prerequisites
 
@@ -40,27 +40,25 @@ This article explains how to install the Az PowerShell module on Windows from th
   ```
 
   > [!IMPORTANT]
-  > If you have the AzureRM PowerShell module installed, see
-  > [Az and AzureRM coexistence](troubleshooting.md#az-and-azurerm-coexistence) before proceeding.
+  > If you have the AzureRM PowerShell module installed, see [Az and AzureRM coexistence][02] before
+  > proceeding.
 
 # [PowerShell 7](#tab/powershell)
 
-- Install a supported version of
-  [PowerShell version 7 or higher](/powershell/scripting/install/installing-powershell-on-windows)
+- Install a supported version of [PowerShell version 7 or higher][03]
 
 # [Windows PowerShell](#tab/windowspowershell)
 
-- Update to
-   [Windows PowerShell 5.1](/powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell)
-- Install [.NET Framework 4.7.2 or later](/dotnet/framework/install)
+- Update to [Windows PowerShell 5.1][04]
+- Install [.NET Framework 4.7.2 or later][05]
 - Update PowerShellGet
 
-   Launch Windows PowerShell 5.1 elevated as an administrator and run the following command to
-   update PowerShellGet:
+  Launch Windows PowerShell 5.1 elevated as an administrator and run the following command to
+  update PowerShellGet:
 
-   ```powershell
-   Install-Module -Name PowerShellGet -Force
-   ```
+  ```powershell
+  Install-Module -Name PowerShellGet -Force
+  ```
 
 ---
 
@@ -78,13 +76,11 @@ This article explains how to install the Az PowerShell module on Windows from th
     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
     ```
 
-  For more information about execution policies, see
-  [about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+  For more information about execution policies, see [about_Execution_Policies][06].
 
 ## Installation
 
-Use the [Install-Module](/powershell/module/powershellget/install-module) cmdlet to install the Az
-PowerShell module:
+Use the [Install-Module][07] cmdlet to install the Az PowerShell module:
 
 ```powershell
 Install-Module -Name Az -Repository PSGallery -Force
@@ -92,8 +88,7 @@ Install-Module -Name Az -Repository PSGallery -Force
 
 ## Update the Az PowerShell module
 
-Use [Update-Module](/powershell/module/powershellget/update-module) to update to the latest version
-of the Az PowerShell module:
+Use [Update-Module][08] to update to the latest version of the Az PowerShell module:
 
 ```powershell
 Update-Module -Name Az -Force
@@ -105,7 +100,7 @@ PowerShell module from your system.
 ## Uninstallation
 
 To remove the Az PowerShell module, see
-[Uninstall the Azure PowerShell module](uninstall-az-ps.md).
+[Uninstall the Azure PowerShell module][09].
 
 ::: zone-end
 
@@ -134,12 +129,11 @@ firewall, or an offline installer is needed.
   ```
 
   > [!IMPORTANT]
-  > If you have the AzureRM PowerShell module installed, see
-  > [Az and AzureRM coexistence](troubleshooting.md#az-and-azurerm-coexistence) before proceeding.
+  > If you have the AzureRM PowerShell module installed, see [Az and AzureRM coexistence][02] before
+  > proceeding.
 
-- Update to
-   [Windows PowerShell 5.1](/powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell)
-- Install [.NET Framework 4.7.2 or later](/dotnet/framework/install)
+- Update to [Windows PowerShell 5.1][04]
+- Install [.NET Framework 4.7.2 or later][05]
 
 - Set the PowerShell script execution to remote signed or less restrictive
 
@@ -156,16 +150,15 @@ firewall, or an offline installer is needed.
     ```
 
   For more information about execution policies, see
-  [about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+  [about_Execution_Policies][06].
 
 ## Installation and update
 
-The MSI package for Azure PowerShell is available from
-[GitHub](https://github.com/Azure/azure-powershell/releases):
+The MSI package for Azure PowerShell is available from [GitHub][14]:
 
-1. Visit
-   [github.com/Azure/azure-powershell/releases](https://github.com/Azure/azure-powershell/releases)
-1. Locate the most recent Az PowerShell module. They are listed chronologically with no name. For example, `9.5.0`
+1. Visit [github.com/Azure/azure-powershell/releases][14]
+1. Locate the most recent Az PowerShell module. They are listed chronologically with no name. For
+   example, `9.5.0`
 1. Scroll down to the end of the patch notes and click the arrow next to "Assets" to reveal the
    MSI options.
 1. Click on the Az-Cmdlets MSI of your choice to start the download
@@ -187,23 +180,37 @@ Connect-AzAccount
 Use your Azure account login credentials to log into the browser window that opens.
 
 You'll need to repeat this step for every new PowerShell session you start. To learn how to persist
-your Azure sign-in across PowerShell sessions, see
-[Azure PowerShell context objects](context-persistence.md).
+your Azure sign-in across PowerShell sessions, see [Azure PowerShell context objects][16].
 
 ## Troubleshooting
 
 For solutions to common installation issues with the Az PowerShell module, see
-[Troubleshoot installation problems with the Azure Az PowerShell module](troubleshooting.md#installation).
+[Troubleshoot installation problems with the Azure Az PowerShell module][17].
 
 ## Provide feedback
 
-To file an issue about the Az PowerShell module, see:
-[file an issue on GitHub](https://github.com/Azure/azure-powershell/issues)
+To file an issue about the Az PowerShell module, see: [file an issue on GitHub][18]
 
-To provide feedback from within a PowerShell session, use the
-[Send-Feedback](/powershell/module/az.accounts/send-feedback) cmdlet.
+To provide feedback from within a PowerShell session, use the [Send-Feedback][19] cmdlet.
 
 ## Next Steps
 
 To learn more about managing your Azure resources with the Az PowerShell module, see
-[Get Started with Azure PowerShell](get-started-azureps.md).
+[Get Started with Azure PowerShell][20].
+
+<!-- updated link references -->
+[01]: /powershell/gallery/overview
+[02]: troubleshooting.md#az-and-azurerm-coexistence
+[03]: /powershell/scripting/install/installing-powershell-on-windows
+[04]: /powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell
+[05]: /dotnet/framework/install
+[06]: /powershell/module/microsoft.powershell.core/about/about_execution_policies
+[07]: /powershell/module/powershellget/install-module
+[08]: /powershell/module/powershellget/update-module
+[09]: uninstall-az-ps.md
+[14]: https://github.com/Azure/azure-powershell/releases
+[16]: context-persistence.md
+[17]: troubleshooting.md#installation
+[18]: https://github.com/Azure/azure-powershell/issues
+[19]: /powershell/module/az.accounts/send-feedback
+[20]: get-started-azureps.md

--- a/docs-conceptual/azps-9.6.0/install-azps-macos.md
+++ b/docs-conceptual/azps-9.6.0/install-azps-macos.md
@@ -11,7 +11,7 @@ title: Install Azure PowerShell on macOS | Microsoft Docs
 # Install Azure PowerShell on macOS
 
 This article explains how to install the Azure PowerShell Az module from
-[the PowerShell Gallery](/powershell/scripting/gallery/overview) on macOS.
+[the PowerShell Gallery][01] on macOS.
 
 The Az PowerShell module is a rollup module. Installing it downloads the generally available Az
 PowerShell modules and makes their cmdlets available for use.
@@ -19,14 +19,13 @@ PowerShell modules and makes their cmdlets available for use.
 ## Prerequisites
 
 - Install a supported version of
-  [PowerShell version 7 or higher](/powershell/scripting/install/installing-powershell-on-macos)
+  [PowerShell version 7 or higher][02]
 
 ## Installation
 
 Open the Terminal or other shell host application and run `pwsh` to start PowerShell.
 
-Use the [Install-Module](/powershell/module/powershellget/install-module) cmdlet to install the Az
-PowerShell module:
+Use the [Install-Module][03] cmdlet to install the Az PowerShell module:
 
 ```powershell
 Install-Module -Name Az -Repository PSGallery -Force
@@ -34,7 +33,7 @@ Install-Module -Name Az -Repository PSGallery -Force
 
 ## Update the Azure PowerShell module
 
-Use the [Update-Module](/powershell/module/powershellget/update-module) cmdlet to update to the
+Use the [Update-Module][04] cmdlet to update to the
 latest version of the Az PowerShell module.
 
 ```powershell
@@ -47,7 +46,7 @@ PowerShell module from your system.
 ## Uninstallation
 
 To remove the Az PowerShell module from your system, see
-[Uninstall the Azure PowerShell module](uninstall-az-ps.md).
+[Uninstall the Azure PowerShell module][05].
 
 ## Sign in
 
@@ -61,23 +60,32 @@ Connect-AzAccount
 Use your Azure account login credentials to log into the browser window that opens.
 
 You'll need to repeat this step for every new PowerShell session you start. To learn how to persist
-your Azure sign-in across PowerShell sessions, see
-[Azure PowerShell context objects](/powershell/azure/context-persistence).
+your Azure sign-in across PowerShell sessions, see [Azure PowerShell context objects][06].
 
 ## Troubleshooting
 
 For solutions to common installation issues with the Az PowerShell module, see
-[Troubleshoot installation problems with the Az PowerShell module](troubleshooting.md#installation).
+[Troubleshoot installation problems with the Az PowerShell module][07].
 
 ## Provide feedback
 
-To file an issue about the Az PowerShell module, see:
-[file an issue on GitHub](https://github.com/Azure/azure-powershell/issues).
+To file an issue about the Az PowerShell module, see: [file an issue on GitHub][08].
 
-To provide feedback from within a PowerShell session, use the
-[Send-Feedback](/powershell/module/az.accounts/send-feedback) cmdlet.
+To provide feedback from within a PowerShell session, use the [Send-Feedback][09] cmdlet.
 
 ## Next steps
 
 To learn more about managing your Azure resources with the Az PowerShell module, see
-[Get Started with Azure PowerShell](get-started-azureps.md).
+[Get Started with Azure PowerShell][10].
+
+<!-- link references -->
+[01]: /powershell/scripting/gallery/overview
+[02]: /powershell/scripting/install/installing-powershell-on-macos
+[03]: /powershell/module/powershellget/install-module
+[04]: /powershell/module/powershellget/update-module
+[05]: uninstall-az-ps.md
+[06]: /powershell/azure/context-persistence
+[07]: troubleshooting.md#installation
+[08]: https://github.com/Azure/azure-powershell/issues
+[09]: /powershell/module/az.accounts/send-feedback
+[10]: get-started-azureps.md

--- a/docs-conceptual/azps-9.6.0/install-azps-windows.md
+++ b/docs-conceptual/azps-9.6.0/install-azps-windows.md
@@ -23,7 +23,7 @@ The recommended installation method and PowerShell version for the Az PowerShell
 ::: zone pivot="windows-psgallery"
 
 This article explains how to install the Az PowerShell module on Windows from the
-[PowerShell Gallery](/powershell/scripting/gallery/overview).
+[PowerShell Gallery][01].
 
 ## Prerequisites
 
@@ -40,19 +40,18 @@ This article explains how to install the Az PowerShell module on Windows from th
   ```
 
   > [!IMPORTANT]
-  > If you have the AzureRM PowerShell module installed, see
-  > [Az and AzureRM coexistence](troubleshooting.md#az-and-azurerm-coexistence) before proceeding.
+  > If you have the AzureRM PowerShell module installed, see [Az and AzureRM coexistence][02] before
+  > proceeding.
 
 # [PowerShell 7](#tab/powershell)
 
 - Install a supported version of
-  [PowerShell version 7 or higher](/powershell/scripting/install/installing-powershell-on-windows)
+  [PowerShell version 7 or higher][03]
 
 # [Windows PowerShell](#tab/windowspowershell)
 
-- Update to
-   [Windows PowerShell 5.1](/powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell)
-- Install [.NET Framework 4.7.2 or later](/dotnet/framework/install)
+- Update to [Windows PowerShell 5.1][04]
+- Install [.NET Framework 4.7.2 or later][05]
 - Update PowerShellGet
 
    Launch Windows PowerShell 5.1 elevated as an administrator and run the following command to
@@ -79,12 +78,11 @@ This article explains how to install the Az PowerShell module on Windows from th
     ```
 
   For more information about execution policies, see
-  [about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+  [about_Execution_Policies][06].
 
 ## Installation
 
-Use the [Install-Module](/powershell/module/powershellget/install-module) cmdlet to install the Az
-PowerShell module:
+Use the [Install-Module][07] cmdlet to install the Az PowerShell module:
 
 ```powershell
 Install-Module -Name Az -Repository PSGallery -Force
@@ -92,8 +90,7 @@ Install-Module -Name Az -Repository PSGallery -Force
 
 ## Update the Az PowerShell module
 
-Use [Update-Module](/powershell/module/powershellget/update-module) to update to the latest version
-of the Az PowerShell module:
+Use [Update-Module][08] to update to the latest version of the Az PowerShell module:
 
 ```powershell
 Update-Module -Name Az -Force
@@ -104,8 +101,7 @@ PowerShell module from your system.
 
 ## Uninstallation
 
-To remove the Az PowerShell module, see
-[Uninstall the Azure PowerShell module](uninstall-az-ps.md).
+To remove the Az PowerShell module, see [Uninstall the Azure PowerShell module][09].
 
 ::: zone-end
 
@@ -134,12 +130,11 @@ firewall, or an offline installer is needed.
   ```
 
   > [!IMPORTANT]
-  > If you have the AzureRM PowerShell module installed, see
-  > [Az and AzureRM coexistence](troubleshooting.md#az-and-azurerm-coexistence) before proceeding.
+  > If you have the AzureRM PowerShell module installed, see [Az and AzureRM coexistence][02] before
+  > proceeding.
 
-- Update to
-   [Windows PowerShell 5.1](/powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell)
-- Install [.NET Framework 4.7.2 or later](/dotnet/framework/install)
+- Update to [Windows PowerShell 5.1][04]
+- Install [.NET Framework 4.7.2 or later][05]
 
 - Set the PowerShell script execution to remote signed or less restrictive
 
@@ -155,19 +150,17 @@ firewall, or an offline installer is needed.
     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
     ```
 
-  For more information about execution policies, see
-  [about_Execution_Policies](/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+  For more information about execution policies, see [about_Execution_Policies][06].
 
 ## Installation and update
 
-The MSI package for Azure PowerShell is available from
-[GitHub](https://github.com/Azure/azure-powershell/releases):
+The MSI package for Azure PowerShell is available from [GitHub][14]:
 
-1. Visit
-   [github.com/Azure/azure-powershell/releases](https://github.com/Azure/azure-powershell/releases)
-1. Locate the most recent Az PowerShell module. They are listed chronologically with no name. For example, `9.5.0`
-1. Scroll down to the end of the patch notes and click the arrow next to "Assets" to reveal the
-   MSI options.
+1. Visit [github.com/Azure/azure-powershell/releases][14]
+1. Locate the most recent Az PowerShell module. They are listed chronologically with no name. For
+   example, `9.5.0`
+1. Scroll down to the end of the patch notes and click the arrow next to "Assets" to reveal the MSI
+   options.
 1. Click on the Az-Cmdlets MSI of your choice to start the download
 
 The installer automatically removes older versions of the Az PowerShell module that were installed
@@ -187,23 +180,37 @@ Connect-AzAccount
 Use your Azure account login credentials to log into the browser window that opens.
 
 You'll need to repeat this step for every new PowerShell session you start. To learn how to persist
-your Azure sign-in across PowerShell sessions, see
-[Azure PowerShell context objects](context-persistence.md).
+your Azure sign-in across PowerShell sessions, see [Azure PowerShell context objects][16].
 
 ## Troubleshooting
 
 For solutions to common installation issues with the Az PowerShell module, see
-[Troubleshoot installation problems with the Azure Az PowerShell module](troubleshooting.md#installation).
+[Troubleshoot installation problems with the Azure Az PowerShell module][17].
 
 ## Provide feedback
 
-To file an issue about the Az PowerShell module, see:
-[file an issue on GitHub](https://github.com/Azure/azure-powershell/issues)
+To file an issue about the Az PowerShell module, see: [file an issue on GitHub][18]
 
-To provide feedback from within a PowerShell session, use the
-[Send-Feedback](/powershell/module/az.accounts/send-feedback) cmdlet.
+To provide feedback from within a PowerShell session, use the [Send-Feedback][19] cmdlet.
 
 ## Next Steps
 
 To learn more about managing your Azure resources with the Az PowerShell module, see
-[Get Started with Azure PowerShell](get-started-azureps.md).
+[Get Started with Azure PowerShell][20].
+
+<!-- link references -->
+[01]: /powershell/gallery/overview
+[02]: troubleshooting.md#az-and-azurerm-coexistence
+[03]: /powershell/scripting/install/installing-powershell-on-windows
+[04]: /powershell/scripting/windows-powershell/install/installing-windows-powershell#upgrading-existing-windows-powershell
+[05]: /dotnet/framework/install
+[06]: /powershell/module/microsoft.powershell.core/about/about_execution_policies
+[07]: /powershell/module/powershellget/install-module
+[08]: /powershell/module/powershellget/update-module
+[09]: uninstall-az-ps.md
+[14]: https://github.com/Azure/azure-powershell/releases
+[16]: context-persistence.md
+[17]: troubleshooting.md#installation
+[18]: https://github.com/Azure/azure-powershell/issues
+[19]: /powershell/module/az.accounts/send-feedback
+[20]: get-started-azureps.md


### PR DESCRIPTION
Fix links to PSGallery docs. We moved the PSGallery docs. This PR updates the links to point to the new URL.

