### PR TITLE
Fix missing TOC - Part 2

### DIFF
--- a/mapping/monikerMapping.json
+++ b/mapping/monikerMapping.json
@@ -3,28 +3,28 @@
         "conceptualToc": "docs-conceptual/azps-9.7.1/toc.yml",
         "conceptualTocUrl": "/powershell/azure/toc.json",
         "packageRoot": "azps-9.7.1",
-        "referenceTocUrl": "/powershell/module/toc.json",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
         "serviceMap": "mapping/az-groupMapping-9.7.1.json"
     },
     "azps-9.6.0": {
         "conceptualToc": "docs-conceptual/azps-9.6.0/toc.yml",
         "conceptualTocUrl": "/powershell/azure/toc.json",
         "packageRoot": "azps-9.6.0",
-        "referenceTocUrl": "/powershell/module/toc.json",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
         "serviceMap": "mapping/az-groupMapping-9.6.0.json"
     },
     "azps-8.3.0": {
         "conceptualToc": "docs-conceptual/azps-8.3.0/toc.yml",
         "conceptualTocUrl": "/powershell/azure/toc.json",
         "packageRoot": "azps-8.3.0",
-        "referenceTocUrl": "/powershell/module/toc.json",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
         "serviceMap": "mapping/az-groupMapping-8.3.0.json"
     },
     "azps-0.10.0": {
         "conceptualToc": "docs-conceptual/azps-0.10.0/toc.yml",
         "conceptualTocUrl": "/powershell/azure/toc.json",
         "packageRoot": "azps-0.10.0",
-        "referenceTocUrl": "/powershell/module/toc.json",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
         "serviceMap": "mapping/az-groupMapping-0.10.0.json"
     },
     "azuredmps-0.9.0-preview": {
@@ -38,14 +38,14 @@
         "conceptualToc": "docs-conceptual/azurermps-2.5.0/toc.yml",
         "conceptualTocUrl": "/powershell/azure/azurerm/toc.json",
         "packageRoot": "azurermps-2.5.0",
-        "referenceTocUrl": "/powershell/module/toc.json",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
         "serviceMap": "mapping/rm-groupMapping-2.5.0.json"
     },
     "azurermps-6.13.0": {
         "conceptualToc": "docs-conceptual/azurermps-6.13.0/toc.yml",
         "conceptualTocUrl": "/powershell/azure/azurerm/toc.json",
         "packageRoot": "azurermps-6.13.0",
-        "referenceTocUrl": "/powershell/module/toc.json",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
         "serviceMap": "mapping/rm-groupMapping-6.13.0.json"
     },
     "azuresmps-4.0.0": {


### PR DESCRIPTION
# PR Summary

This changes try to fixes the problem that reference TOC is missing in the pages when accessing the conceptual pages.
Example: https://learn.microsoft.com/en-us/powershell/azure/?view=azps-9.7.1 
![image](https://user-images.githubusercontent.com/8327019/236592621-615df70e-7075-4a36-85f1-4d00248c9df1.png)

This PR build result can be used to validate.

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide
