### PR TITLE
Adds link to survey in docs

### DIFF
--- a/docs-conceptual/azps-10.2.0/command-line-tools-survey-guidance.md
+++ b/docs-conceptual/azps-10.2.0/command-line-tools-survey-guidance.md
@@ -10,7 +10,7 @@ title: Azure command line tools survey guidance
 
 # Azure command line tools survey guidance
 
-When using Azure PowerShell, you may be invited to participate in a survey to tell us about your
+When using Azure PowerShell, you may be invited to participate in [a survey](https://go.microsoft.com/fwlink/?linkid=2201766) to tell us about your
 experience. By responding to the survey, you help to identify common issues and areas for
 improvement. Understanding your experiences and opinions helps to make future releases of Azure
 command line tools better for you and others.


### PR DESCRIPTION
# PR Summary

When executing a long-running command, I was prompted with. 

> [Survey] Help us improve Azure PowerShell by sharing your experience. This survey should take about 5 minutes. Run 'Open-AzSurveyLink' to open in browser. Learn more at https://go.microsoft.com/fwlink/?linkid=2202892

Link id 2202892 opens to the docs page at https://learn.microsoft.com/en-us/powershell/azure/command-line-tools-survey-guidance

`Open-AzSurveyLink` opens to [link id 2201766](https://go.microsoft.com/fwlink/?linkid=2201766)

Add a link to the actual survey in the docs page to save time and reduce bounce rate. Don't want to wait to the end of my long-running command or open an new terminal when I should be able to "just click".

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide

----

n.b. the aka.ms example given at https://learn.microsoft.com/en-us/powershell/module/az.accounts/open-azsurveylink#example-1 appears to be out-of-date.

```powershell
Open-AzSurveyLink

Opening the default browser to https://aka.ms/azpssurvey?Q_CHL=INTERCEPT
```

https://wheregoes.com/trace/20233722592/

![image](https://github.com/MicrosoftDocs/azure-docs-powershell/assets/10898767/011ee855-fd90-42ca-b63b-7cad9a72e385)
![image](https://github.com/MicrosoftDocs/azure-docs-powershell/assets/10898767/2c9dac62-092f-4a3e-aa0d-651cd8cac60f)

