### PR TITLE
Remove the fixed issue

### DIFF
--- a/docs-conceptual/azps-11.1.0/troubleshooting.md
+++ b/docs-conceptual/azps-11.1.0/troubleshooting.md
@@ -109,23 +109,6 @@ AzAd cmdlets under Az.Resources now support [query parameters](/graph/query-para
 [search query parameters](/graph/search-query-parameter). For details about the syntax, see the
 previously referenced links.
 
-## Get-AzAdGroupMember doesn't return service principals
-
-Due to limitations with the current Graph API, service principals aren't returned by
-[Get-AzAdGroupMember](/powershell/module/az.resources/get-azadgroupmember) in Az 7.x. As a
-workaround, [Invoke-AzRestMethod](/powershell/module/az.accounts/invoke-azrestmethod) can be used
-with the beta version of the Microsoft Graph API.
-
-The following example requires the Az PowerShell module. Replace `myGroupName` in the first line
-with the name of your group.
-
-```azurepowershell-interactive
-$Group = Get-AzADGroup -DisplayName myGroupName
-((Invoke-AzRestMethod -Uri "https://graph.microsoft.com/beta/groups/$($Group.id)/members").Content |
-  ConvertFrom-Json).value |
-  Select-Object -Property DisplayName, Id, @{label='OdataType';expression={$_.'@odata.type'}}
-```
-
 ## Command found but could not be loaded
 
 The following message is returned by PowerShell when you attempt to run any of the Az PowerShell commands.


### PR DESCRIPTION


# PR Summary

"Get-AzAdGroupMember doesn't return service principals" issue is fixed. 
The current version of the Get-AzAdGroupMember cmdlet returns service principals.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/azure/azps-docs-style-guide
