### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 5)

### DIFF
--- a/azps-0.10.0/Az.Resources/Add-AzADGroupMember.md
+++ b/azps-0.10.0/Az.Resources/Add-AzADGroupMember.md
@@ -61,15 +61,15 @@ Adds a user to an existing AD group.
 PS C:\> Add-AzADGroupMember -MemberObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -TargetGroupObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
 ```
 
-Adds the user with object id '00001111-aaaa-2222-bbbb-3333cccc4444' to the group with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Adds the user with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' to the group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - Add a user to a group by piping
 
 ```
-PS C:\> Get-AzADGroup -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Add-AzADGroupMember -MemberObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Get-AzADGroup -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Add-AzADGroupMember -MemberObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
 ```
 
-Gets the group with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes it to the Add-AzADGroupMember cmdlet to add the user to that group.
+Gets the group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes it to the Add-AzADGroupMember cmdlet to add the user to that group.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Get-AzADAppCredential.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADAppCredential.md
@@ -47,18 +47,18 @@ This command will retrieve all of the credential properties (but not the credent
 ### Example 1 - Get application credentials by object id
 
 ```
-PS C:\> Get-AzADAppCredential -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Get-AzADAppCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Returns a list of credentials associated with the application having object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Returns a list of credentials associated with the application having object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - Get application credentials by piping
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Get-AzADAppCredential
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Get-AzADAppCredential
 ```
 
-Gets the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes it to the Get-AzADAppCredential cmdlet to list all of the credentials for that application.
+Gets the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes it to the Get-AzADAppCredential cmdlet to list all of the credentials for that application.
 
 ## PARAMETERS
 
@@ -162,4 +162,3 @@ Parameters: ApplicationObject (ByValue)
 [Remove-AzADAppCredential](./Remove-AzADAppCredential.md)
 
 [Get-AzADApplication](./Get-AzADApplication.md)
-

--- a/azps-0.10.0/Az.Resources/Get-AzADApplication.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADApplication.md
@@ -85,10 +85,10 @@ Gets the application with identifier uri as "http://mySecretApp1".
 ### Example 4 - Get application by object id
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Gets the application with the object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Gets the application with the object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Get-AzADGroup.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADGroup.md
@@ -62,10 +62,10 @@ Lists the first 100 AD groups in a tenant.
 ### Example 3 - Get AD group by object id
 
 ```
-PS C:\> Get-AzADGroup -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Get-AzADGroup -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Gets an AD group with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Gets an AD group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 4 - List groups by search string
 
@@ -216,4 +216,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
 
 [Get-AzADGroupMember](./Get-AzADGroupMember.md)
-

--- a/azps-0.10.0/Az.Resources/Get-AzADGroupMember.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADGroupMember.md
@@ -44,7 +44,7 @@ Lists members of an AD group in the current tenant.
 PS C:\> Get-AzADGroupMember -GroupObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
 ```
 
-Lists members of the AD group with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Lists members of the AD group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - List members by AD group object id using paging
 
@@ -52,15 +52,15 @@ Lists members of the AD group with object id '00001111-aaaa-2222-bbbb-3333cccc44
 PS C:\> Get-AzADGroupMember -GroupObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -First 100
 ```
 
-Lists the first 100 members of the AD group with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Lists the first 100 members of the AD group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 3 - List members by piping
 
 ```
-PS C:\> Get-AzADGroup -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Get-AzADGroupMember
+PS C:\> Get-AzADGroup -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Get-AzADGroupMember
 ```
 
-Gets the AD group with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes it to the Get-AzADGroupMember cmdlet to list all members in that group.
+Gets the AD group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes it to the Get-AzADGroupMember cmdlet to list all members in that group.
 
 ## PARAMETERS
 
@@ -190,4 +190,3 @@ Parameters: GroupObject (ByValue)
 [Get-AzADUser](./Get-AzADUser.md)
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
-

--- a/azps-0.10.0/Az.Resources/Get-AzADServicePrincipal.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADServicePrincipal.md
@@ -97,10 +97,10 @@ Lists all AD service principals whose display name start with "Web".
 ### Example 5 - List service principals by piping
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Get-AzADServicePrincipal
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Get-AzADServicePrincipal
 ```
 
-Gets the AD application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes it to the Get-AzADServicePrincipal cmdlet to list all service principals for that application.
+Gets the AD application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes it to the Get-AzADServicePrincipal cmdlet to list all service principals for that application.
 
 ## PARAMETERS
 
@@ -282,4 +282,3 @@ Parameters: ApplicationObject (ByValue)
 [Get-AzADApplication](./Get-AzADApplication.md)
 
 [Get-AzADSpCredential](./Get-AzADSpCredential.md)
-

--- a/azps-0.10.0/Az.Resources/Get-AzADSpCredential.md
+++ b/azps-0.10.0/Az.Resources/Get-AzADSpCredential.md
@@ -54,18 +54,18 @@ Returns a list of credentials associated with the service principal with SPN 'ht
 ### Example 2 - List credentials by object id
 
 ```
-PS C:\> Get-AzADSpCredential -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Get-AzADSpCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Returns a list of credentials associated with the service principal with object id "00001111-aaaa-2222-bbbb-3333cccc4444".
+Returns a list of credentials associated with the service principal with object id "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb".
 
 ### Example 3 - List credentials by piping
 
 ```
-PS C:\> Get-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Get-AzADSpCredential
+PS C:\> Get-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Get-AzADSpCredential
 ```
 
-Gets the service principal with object id "00001111-aaaa-2222-bbbb-3333cccc4444" and pipes it to the Get-AzADSpCredential cmdlet to list all credentials for that service principal.
+Gets the service principal with object id "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" and pipes it to the Get-AzADSpCredential cmdlet to list all credentials for that service principal.
 
 ## PARAMETERS
 
@@ -169,4 +169,3 @@ Parameters: ServicePrincipalObject (ByValue)
 [Remove-AzADSpCredential](./Remove-AzADSpCredential.md)
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
-

--- a/azps-0.10.0/Az.Resources/Get-AzManagementGroup.md
+++ b/azps-0.10.0/Az.Resources/Get-AzManagementGroup.md
@@ -37,13 +37,13 @@ PS C:\> Get-AzManagementGroup
 Id          : /providers/Microsoft.Management/managementGroups/TestGroup
 Type        : /providers/Microsoft.Management/managementGroups
 Name        : TestGroup
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName : TestGroupDisplayName
 
 Id          : /providers/Microsoft.Management/managementGroups/TestGroupChild
 Type        : /providers/Microsoft.Management/managementGroups
 Name        : TestGroupChild
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName : TestGroupChildDisplayName
 ```
 
@@ -54,7 +54,7 @@ PS C:\> Get-AzManagementGroup -GroupName TestGroup
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -71,7 +71,7 @@ PS C:\> $response
 Id                : /providers/Microsoft.Management/managementGroups/TestGroupParent
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroupParent
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupParent
 UpdatedTime       : 2/1/2018 11:15:46 AM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -99,7 +99,7 @@ PS C:\> $response
 Id                : /providers/Microsoft.Management/managementGroups/TestGroupParent
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroupParent
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupParent
 UpdatedTime       : 2/1/2018 11:15:46 AM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9

--- a/azps-0.10.0/Az.Resources/Get-AzPolicyDefinition.md
+++ b/azps-0.10.0/Az.Resources/Get-AzPolicyDefinition.md
@@ -85,10 +85,10 @@ This command gets the policy definition named VMPolicyDefinition from the manage
 
 ### Example 4: Get all built-in policy definitions from subscription
 ```
-PS C:\> Get-AzPolicyDefinition -SubscriptionId '3bf44b72-c631-427a-b8c8-53e2595398ca' -Builtin
+PS C:\> Get-AzPolicyDefinition -SubscriptionId 'aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e' -Builtin
 ```
 
-This command gets all built-in policy definitions from the subscription with ID 3bf44b72-c631-427a-b8c8-53e2595398ca.
+This command gets all built-in policy definitions from the subscription with ID aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e.
 
 ## PARAMETERS
 
@@ -305,5 +305,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-AzPolicyDefinition](./Remove-AzPolicyDefinition.md)
 
 [Set-AzPolicyDefinition](./Set-AzPolicyDefinition.md)
-
-

--- a/azps-0.10.0/Az.Resources/Get-AzPolicySetDefinition.md
+++ b/azps-0.10.0/Az.Resources/Get-AzPolicySetDefinition.md
@@ -71,10 +71,10 @@ This command gets the policy set definition named VMPolicySetDefinition from the
 
 ### Example 3: Get policy set definition from subscription by name
 ```
-PS C:\> Get-AzPolicySetDefinition -Name 'VMPolicySetDefinition' -subscriptionId '3bf44b72-c631-427a-b8c8-53e2595398ca'
+PS C:\> Get-AzPolicySetDefinition -Name 'VMPolicySetDefinition' -subscriptionId 'aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e'
 ```
 
-This command gets the policy definition named VMPolicySetDefinition from the subscription with ID 3bf44b72-c631-427a-b8c8-53e2595398ca.
+This command gets the policy definition named VMPolicySetDefinition from the subscription with ID aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e.
 
 ### Example 4: Get all custom policy set definitions from management group
 ```

--- a/azps-0.10.0/Az.Resources/New-AzADAppCredential.md
+++ b/azps-0.10.0/Az.Resources/New-AzADAppCredential.md
@@ -74,10 +74,10 @@ The application is identified by supplying either the application object id or a
 
 ```
 PS C:\> $SecureStringPassword = ConvertTo-SecureString -String "password" -AsPlainText -Force
-PS C:\> New-AzADAppCredential -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -Password $SecureStringPassword
+PS C:\> New-AzADAppCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -Password $SecureStringPassword
 ```
 
-A new password credential is added to the existing appplication with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+A new password credential is added to the existing appplication with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - Create a new application credential using a certificate
 
@@ -95,10 +95,10 @@ The supplied base64 encoded public X509 certificate ("myapp.cer") is added to th
 
 ```
 PS C:\> $SecureStringPassword = ConvertTo-SecureString -String "password" -AsPlainText -Force
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | New-AzADAppCredential -Password $SecureStringPassword
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | New-AzADAppCredential -Password $SecureStringPassword
 ```
 
-Gets the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the New-AzADAppCredential to create a new application credential for that application with the given password.
+Gets the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the New-AzADAppCredential to create a new application credential for that application with the given password.
 
 ## PARAMETERS
 
@@ -321,4 +321,3 @@ Parameters: ApplicationObject (ByValue)
 [Remove-AzADAppCredential](./Remove-AzADAppCredential.md)
 
 [Get-AzADApplication](./Get-AzADApplication.md)
-

--- a/azps-0.10.0/Az.Resources/New-AzADServicePrincipal.md
+++ b/azps-0.10.0/Az.Resources/New-AzADServicePrincipal.md
@@ -209,10 +209,10 @@ Creates a new AD service principal for the application with application id '0000
 ### Example 6 - Create a new AD service principal using piping
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | New-AzADServicePrincipal
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | New-AzADServicePrincipal
 ```
 
-Gets the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the New-AzADServicePrincipal cmdlet to create a new AD service principal for that application.
+Gets the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the New-AzADServicePrincipal cmdlet to create a new AD service principal for that application.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/New-AzADSpCredential.md
+++ b/azps-0.10.0/Az.Resources/New-AzADSpCredential.md
@@ -62,7 +62,7 @@ The service principal is identified by supplying either the object id or service
 ### Example 1 - Create a new service principal credential using a generated password
 
 ```
-PS C:\> New-AzADSpCredential -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> New-AzADSpCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 
 Secret    : System.Security.SecureString
 StartDate : 11/12/2018 9:36:05 PM
@@ -71,7 +71,7 @@ KeyId     : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 Type      : Password
 ```
 
-A new password credential is added to the existing service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+A new password credential is added to the existing service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - Create a new service principal credential using a certificate
 
@@ -88,7 +88,7 @@ The supplied base64 encoded public X509 certificate ("myapp.cer") is added to th
 ### Example 3 - Create a new service principal credential using piping
 
 ```
-PS C:\> Get-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | New-AzADSpCredential
+PS C:\> Get-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | New-AzADSpCredential
 
 Secret    : System.Security.SecureString
 StartDate : 11/12/2018 9:36:05 PM
@@ -97,7 +97,7 @@ KeyId     : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 Type      : Password
 ```
 
-Gets the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the New-AzADSpCredential to create a new service principal credential for that service principal with a generated password.
+Gets the service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the New-AzADSpCredential to create a new service principal credential for that service principal with a generated password.
 
 ## PARAMETERS
 
@@ -312,6 +312,3 @@ Parameters: ServicePrincipalObject (ByValue)
 [Remove-AzADSpCredential](./Remove-AzADSpCredential.md)
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
-
-
-

--- a/azps-0.10.0/Az.Resources/New-AzManagementGroup.md
+++ b/azps-0.10.0/Az.Resources/New-AzManagementGroup.md
@@ -39,7 +39,7 @@ PS C:\> New-AzManagementGroup -GroupName "TestGroup"
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroup
 UpdatedTime       : 2/1/2018 11:06:27 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444
@@ -57,7 +57,7 @@ PS C:\> New-AzManagementGroup -GroupName "TestGroup" -DisplayName "TestGroupDisp
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroup
 UpdatedTime       : 2/1/2018 11:06:27 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444
@@ -75,7 +75,7 @@ PS C:\> New-AzManagementGroup -GroupName "TestGroup" -DisplayName "TestGroupDisp
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444
@@ -92,7 +92,7 @@ PS C:\> New-AzManagementGroup -GroupName "TestGroup" -ParentObject $parentObject
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444

--- a/azps-0.10.0/Az.Resources/New-AzManagementGroupSubscription.md
+++ b/azps-0.10.0/Az.Resources/New-AzManagementGroupSubscription.md
@@ -26,7 +26,7 @@ The **New-AzManagementGroupSubscription** cmdlet adds a Subscription to a Manage
 
 ### Example 1: Add Subscription to a Management Group
 ```
-PS C:\> New-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId 2120692d-35c3-44c8-81f5-631fa7351726
+PS C:\> New-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ## PARAMETERS

--- a/azps-0.10.0/Az.Resources/New-AzPolicyDefinition.md
+++ b/azps-0.10.0/Az.Resources/New-AzPolicyDefinition.md
@@ -96,12 +96,12 @@ PS C:\> New-AzPolicyDefinition -Name 'VMPolicyDefinition' -Metadata '{"Category"
 
 
 Name               : VMPolicyDefinition
-ResourceId         : /subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/policyDefinitions/VMPolicyDefinition
+ResourceId         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/providers/Microsoft.Authorization/policyDefinitions/VMPolicyDefinition
 ResourceName       : VMPolicyDefinition
 ResourceType       : Microsoft.Authorization/policyDefinitions
-SubscriptionId     : 11111111-1111-1111-1111-111111111111
+SubscriptionId     : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Properties         : @{displayName=VMPolicyDefinition; policyType=Custom; mode=All; metadata=; policyRule=}
-PolicyDefinitionId : /subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/policyDefinitions/VMPolicyDefinition
+PolicyDefinitionId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/providers/Microsoft.Authorization/policyDefinitions/VMPolicyDefinition
 ```
 
 This command creates a policy definition named VMPolicyDefinition with metadata indicating its category is "Virtual Machine".
@@ -344,5 +344,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-AzPolicyDefinition](./Remove-AzPolicyDefinition.md)
 
 [Set-AzPolicyDefinition](./Set-AzPolicyDefinition.md)
-
-

--- a/azps-0.10.0/Az.Resources/New-AzRoleAssignment.md
+++ b/azps-0.10.0/Az.Resources/New-AzRoleAssignment.md
@@ -121,7 +121,7 @@ PS C:\> Get-AzADGroup -SearchString "Christine Koch Team"
           -----------                    ----                           --------
           Christine Koch Team                                           00001111-aaaa-2222-bbbb-3333cccc4444
 
-PS C:\> New-AzRoleAssignment -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -RoleDefinitionName Contributor  -ResourceGroupName rg1
+PS C:\> New-AzRoleAssignment -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -RoleDefinitionName Contributor  -ResourceGroupName rg1
 ```
 
 Grant access to a security group
@@ -135,7 +135,7 @@ Grant access to a user at a resource (website)
 
 ### Example 4
 ```
-PS C:\> New-AzRoleAssignment -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -RoleDefinitionName "Virtual Machine Contributor" -ResourceName Devices-Engineering-ProjectRND -ResourceType Microsoft.Network/virtualNetworks/subnets -ParentResource virtualNetworks/VNET-EASTUS-01 -ResourceGroupName Network
+PS C:\> New-AzRoleAssignment -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -RoleDefinitionName "Virtual Machine Contributor" -ResourceName Devices-Engineering-ProjectRND -ResourceType Microsoft.Network/virtualNetworks/subnets -ParentResource virtualNetworks/VNET-EASTUS-01 -ResourceGroupName Network
 ```
 
 Grant access to a group at a nested resource (subnet)

--- a/azps-0.10.0/Az.Resources/Remove-AzADAppCredential.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADAppCredential.md
@@ -49,10 +49,10 @@ The credential to be removed is identified by its key ID.
 ### Example 1 - Remove a specific credential from an application
 
 ```
-PS C:\> Remove-AzADAppCredential -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -KeyId 9044423a-60a3-45ac-9ab1-09534157ebb
+PS C:\> Remove-AzADAppCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -KeyId 9044423a-60a3-45ac-9ab1-09534157ebb
 ```
 
-Removes the credential with key id '9044423a-60a3-45ac-9ab1-09534157ebb' from the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Removes the credential with key id '9044423a-60a3-45ac-9ab1-09534157ebb' from the application with object id 'ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0'.
 
 ### Example 2 - Remove all credentials from an application
 
@@ -65,10 +65,10 @@ Removes all credentials from the application with application id '00001111-aaaa-
 ### Example 3 - Remove all credentials using piping
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADAppCredential
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADAppCredential
 ```
 
-Gets the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Remove-AzADAppCredential cmdlet and removes all credentials from that application.
+Gets the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Remove-AzADAppCredential cmdlet and removes all credentials from that application.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Remove-AzADApplication.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADApplication.md
@@ -47,10 +47,10 @@ Deletes the Microsoft Entra application.
 ### Example 1 - Remove application by object id
 
 ```
-PS C:\> Remove-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Remove-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Removes the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' from the tenant.
+Removes the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' from the tenant.
 
 ### Example 2 - Remove application by application id
 
@@ -63,10 +63,10 @@ Removes the application with application id '00001111-aaaa-2222-bbbb-3333cccc444
 ### Example 3 - Remove application by piping
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADApplication
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADApplication
 ```
 
-Gets the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Remove-AzADApplication cmdlet to remove the application from the tenant.
+Gets the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Remove-AzADApplication cmdlet to remove the application from the tenant.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Remove-AzADGroup.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADGroup.md
@@ -40,18 +40,18 @@ Deletes an active directory group.
 ### Example 1 - Remove a group by object id
 
 ```
-PS C:\> Remove-AzADGroup -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Remove-AzADGroup -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Removes the group with object id '00001111-aaaa-2222-bbbb-3333cccc4444' from the tenant.
+Removes the group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' from the tenant.
 
 ### Example 2 - Remove a group by piping
 
 ```
-PS C:\> Get-AzADGroup -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADGroup
+PS C:\> Get-AzADGroup -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADGroup
 ```
 
-Gets the group with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to Remove-AzADGroup to remove the group from the tenant.
+Gets the group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to Remove-AzADGroup to remove the group from the tenant.
 
 ## PARAMETERS
 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.0.0.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
