### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 6)

### DIFF
--- a/azps-0.10.0/Az.Resources/Remove-AzADGroupMember.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADGroupMember.md
@@ -67,15 +67,15 @@ Removes a user from an AD group.
 PS C:\> Remove-AzADGroup -MemberObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -GroupObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
 ```
 
-Removes the user with object id '00001111-aaaa-2222-bbbb-3333cccc4444' from the group with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Removes the user with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' from the group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - Remove a user from a group by piping
 
 ```
-PS C:\> Get-AzADGroup -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADGroupMember -MemberObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Get-AzADGroup -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADGroupMember -MemberObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
 ```
 
-Gets the group with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes it to the Remove-AzADGroupMember cmdlet to remove the user to that group.
+Gets the group with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes it to the Remove-AzADGroupMember cmdlet to remove the user to that group.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Remove-AzADServicePrincipal.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADServicePrincipal.md
@@ -59,10 +59,10 @@ Deletes the Microsoft Entra service principal.
 ### Example 1 - Remove a service principal by object id
 
 ```
-PS C:\> Remove-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Remove-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Removes the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Removes the service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 2 - Remove a service principal by application id
 
@@ -83,10 +83,10 @@ Remove the service principal with service principal name "MyServicePrincipal"
 ### Example 4 - Remove a service principal by piping
 
 ```
-PS C:\> Get-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADServicePrincipal
+PS C:\> Get-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADServicePrincipal
 ```
 
-Gets the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Remove-AzADServicePrincipal cmdlet to remove that service principal.
+Gets the service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Remove-AzADServicePrincipal cmdlet to remove that service principal.
 
 ### Example 5 - Remove a service principal by piping an application
 

--- a/azps-0.10.0/Az.Resources/Remove-AzADSpCredential.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADSpCredential.md
@@ -49,10 +49,10 @@ The credential to be removed is identified by its key ID if an individual creden
 ### Example 1 - Remove a specific credential from a service principal
 
 ```
-PS C:\> Remove-AzADSpCredential -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -KeyId 9044423a-60a3-45ac-9ab1-09534157ebb
+PS C:\> Remove-AzADSpCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -KeyId 9044423a-60a3-45ac-9ab1-09534157ebb
 ```
 
-Removes the credential with key id '9044423a-60a3-45ac-9ab1-09534157ebb' from the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Removes the credential with key id '9044423a-60a3-45ac-9ab1-09534157ebb' from the service principal with object id 'ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0'.
 
 ### Example 2 - Remove all credentials from a service principal
 
@@ -65,10 +65,10 @@ Removes all credentials from the service principal with the SPN "http://test123"
 ### Example 3 - Remove all credentials from a service principal using piping
 
 ```
-PS C:\> Get-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADSpCredential
+PS C:\> Get-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADSpCredential
 ```
 
-Gets the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Remove-AzADSpCredential cmdlet to remove all credentials from that service principal.
+Gets the service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Remove-AzADSpCredential cmdlet to remove all credentials from that service principal.
 
 ## PARAMETERS
 
@@ -249,4 +249,3 @@ Parameters: ServicePrincipalObject (ByValue)
 [New-AzADSpCredential](./New-AzADSpCredential.md)
 
 [Get-AzADServicePrincipal](./Get-AzADServicePrincipal.md)
-

--- a/azps-0.10.0/Az.Resources/Remove-AzADUser.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzADUser.md
@@ -61,18 +61,18 @@ Removes the user with user principal name "foo@domain.com" from the tenant.
 ### Example 2 - Remove a user by object id
 
 ```
-PS C:\> Remove-AzADUser -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444
+PS C:\> Remove-AzADUser -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
-Removes the user with object id '00001111-aaaa-2222-bbbb-3333cccc4444' from the tenant.
+Removes the user with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' from the tenant.
 
 ### Example 3 - Remove a user by piping
 
 ```
-PS C:\> Get-AzADUser -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Remove-AzADUser
+PS C:\> Get-AzADUser -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Remove-AzADUser
 ```
 
-Gets the user with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Remove-AzADUser cmdlet to remove the user from the tenant.
+Gets the user with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Remove-AzADUser cmdlet to remove the user from the tenant.
 
 ## PARAMETERS
 
@@ -250,5 +250,3 @@ Parameters: InputObject (ByValue)
 [New-AzADUser](./New-AzADUser.md)
 
 [Get-AzADUser](./Get-AzADUser.md)
-
-

--- a/azps-0.10.0/Az.Resources/Remove-AzManagementGroupSubscription.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzManagementGroupSubscription.md
@@ -26,7 +26,7 @@ The **Remove-AzManagementGroupSubscription** cmdlet removes a Subscription from 
 
 ### Example 1 - Remove Subscription from a Management Group
 ```
-PS C:\> Remove-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId 2120692d-35c3-44c8-81f5-631fa7351726
+PS C:\> Remove-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ## PARAMETERS

--- a/azps-0.10.0/Az.Resources/Remove-AzRoleAssignment.md
+++ b/azps-0.10.0/Az.Resources/Remove-AzRoleAssignment.md
@@ -118,7 +118,7 @@ Removes a role assignment for john.doe@contoso.com who is assigned to the Reader
 
 ### Example 2
 ```
-PS C:\> Remove-AzRoleAssignment -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -RoleDefinitionName Reader
+PS C:\> Remove-AzRoleAssignment -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -RoleDefinitionName Reader
 ```
 
 Removes the role assignment to the group principal identified by the ObjectId and assigned to the Reader role.

--- a/azps-0.10.0/Az.Resources/Update-AzADApplication.md
+++ b/azps-0.10.0/Az.Resources/Update-AzADApplication.md
@@ -44,26 +44,26 @@ To update the credentials associated with this application, please use the New-A
 ### Example 1 - Update the display name of an application
 
 ```
-PS C:\> Update-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -DisplayName MyNewDisplayName
+PS C:\> Update-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -DisplayName MyNewDisplayName
 ```
 
-Updates the display name of the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' to be 'MyNewDisplayName'.
+Updates the display name of the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' to be 'MyNewDisplayName'.
 
 ### Example 2 - Update all properties of an application
 
 ```
-PS C:\> Update-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -DisplayName MyNewDisplayName -HomePage https://www.microsoft.com -IdentifierUris "https://UpdateAppUri"
+PS C:\> Update-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -DisplayName MyNewDisplayName -HomePage https://www.microsoft.com -IdentifierUris "https://UpdateAppUri"
 ```
 
-Updates the properties of an application with object id '00001111-aaaa-2222-bbbb-3333cccc4444'.
+Updates the properties of an application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb'.
 
 ### Example 3 - Update the display name of an application using piping
 
 ```
-PS C:\> Get-AzADApplication -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Update-AzADApplication -DisplayName MyNewDisplayName
+PS C:\> Get-AzADApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Update-AzADApplication -DisplayName MyNewDisplayName
 ```
 
-Gets the application with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Update-AzADApplication cmdlet to update the display name of the application to "MyNewDisplayName".
+Gets the application with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Update-AzADApplication cmdlet to update the display name of the application to "MyNewDisplayName".
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Update-AzADServicePrincipal.md
+++ b/azps-0.10.0/Az.Resources/Update-AzADServicePrincipal.md
@@ -53,18 +53,18 @@ To update the properties associated with the underlying application, please use 
 ### Example 1 - Update the display name of a service principal
 
 ```
-PS C:\> Update-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -DisplayName MyNewDisplayName
+PS C:\> Update-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -DisplayName MyNewDisplayName
 ```
 
-Updates the display name of the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444' to be 'MyNewDisplayName'.
+Updates the display name of the service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' to be 'MyNewDisplayName'.
 
 ### Example 2 - Update the display name of a service principal using piping
 
 ```
-PS C:\> Get-AzADServicePrincipal -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Update-AzADServicePrincipal -DisplayName MyNewDisplayName
+PS C:\> Get-AzADServicePrincipal -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Update-AzADServicePrincipal -DisplayName MyNewDisplayName
 ```
 
-Gets the service principal with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Update-AzADServicePrincipal cmdlet to update the display name of the service principal to "MyNewDisplayName".
+Gets the service principal with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Update-AzADServicePrincipal cmdlet to update the display name of the service principal to "MyNewDisplayName".
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Update-AzADUser.md
+++ b/azps-0.10.0/Az.Resources/Update-AzADUser.md
@@ -51,10 +51,10 @@ For more information: https://msdn.microsoft.com/en-us/library/azure/ad/graph/ap
 ### Example 1 - Update the display name of a user using object id
 
 ```
-PS C:\> Update-AzADUser -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -DisplayName MyNewDisplayName
+PS C:\> Update-AzADUser -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -DisplayName MyNewDisplayName
 ```
 
-Updates the display name of the user with object id '00001111-aaaa-2222-bbbb-3333cccc4444' to be 'MyNewDisplayName'.
+Updates the display name of the user with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' to be 'MyNewDisplayName'.
 
 ### Example 2 - Update the display name of a user using user principal name
 
@@ -67,10 +67,10 @@ Updates the display name of the user with user principal name 'foo@domain.com' t
 ### Example 3 - Update the display name of a user using piping
 
 ```
-PS C:\> Get-AzADUser -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 | Update-AzADUser -DisplayName MyNewDisplayName
+PS C:\> Get-AzADUser -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb | Update-AzADUser -DisplayName MyNewDisplayName
 ```
 
-Gets the user with object id '00001111-aaaa-2222-bbbb-3333cccc4444' and pipes that to the Update-AzADUser cmdlet to update the display name of that user to 'MyNewDisplayName'.
+Gets the user with object id 'aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb' and pipes that to the Update-AzADUser cmdlet to update the display name of that user to 'MyNewDisplayName'.
 
 ## PARAMETERS
 

--- a/azps-0.10.0/Az.Resources/Update-AzManagementGroup.md
+++ b/azps-0.10.0/Az.Resources/Update-AzManagementGroup.md
@@ -52,7 +52,7 @@ PS C:\> Update-AzManagementGroup -Group "TestGroup" -DisplayName "New Display Na
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : New Display Name
 UpdatedTime       : 2/1/2018 12:03:37 PM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -68,7 +68,7 @@ PS C:\> Update-AzManagementGroup -Group "TestGroup" -ParentId "/providers/Micros
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroup
 UpdatedTime       : 2/1/2018 12:03:37 PM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -84,7 +84,7 @@ PS C:\> Get-AzManagementGroup -GroupName "TestGroup" | Update-AzManagementGroup 
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestDisplayName
 UpdatedTime       : 2/1/2018 12:03:37 PM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -101,7 +101,7 @@ PS C:\> Update-AzManagementGroup -GroupName "TestGroup" -ParentObject $parentObj
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.0.0.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
