### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 4)

### DIFF
--- a/azps-12.5.0/Az.Automation/New-AzAutomationConnection.md
+++ b/azps-12.5.0/Az.Automation/New-AzAutomationConnection.md
@@ -28,7 +28,7 @@ The **New-AzAutomationConnection** cmdlet creates a connection in Azure Automati
 
 ### Example 1: Create a connection for ConnectionTypeName=Azure
 ```powershell
-$FieldValues = @{"AutomationCertificateName"="ContosoCertificate";"SubscriptionID"="81b59010-dc55-45b7-89cd-5ca26db62472"}
+$FieldValues = @{"AutomationCertificateName"="ContosoCertificate";"SubscriptionID"="aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"}
 New-AzAutomationConnection -Name "Connection12" -ConnectionTypeName Azure -ConnectionFieldValues $FieldValues -ResourceGroupName "ResourceGroup01" -AutomationAccountName "AutomationAccount01"
 ```
 
@@ -39,9 +39,9 @@ The command uses the connection field values in $FieldValues.
 ### Example 2: Create a connection for ConnectionTypeName=AzureServicePrincipal
 ```powershell
 $Thumbprint = "0SZTNJ34TCCMUJ5MJZGR8XQD3S0RVHJBA33Z8ZXV"
-$TenantId = "00001111-aaaa-2222-bbbb-3333cccc4444"
+$TenantId = "aaaabbbb-0000-cccc-1111-dddd2222eeee"
 $ApplicationId = "00001111-aaaa-2222-bbbb-3333cccc4444"
-$SubscriptionId = "81b59010-dc55-45b7-89cd-5ca26db62472"
+$SubscriptionId = "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 $RunAsAccountConnectionFieldValues = @{"ApplicationId" = $ApplicationId; "TenantId" = $TenantId; "CertificateThumbprint" = $Thumbprint; "SubscriptionId" = $SubscriptionId}
 New-AzAutomationConnection -Name "Connection13" -ConnectionTypeName AzureServicePrincipal -ConnectionFieldValues $RunAsAccountConnectionFieldValues -ResourceGroupName "ResourceGroup01" -AutomationAccountName "AutomationAccount01"
 ```
@@ -52,7 +52,7 @@ This ConnectionTypeName=AzureServicePrincipal is mainly used for Azure Run As Ac
 ### Example 3: Create a connection for ConnectionTypeName=AzureClassicCertificate
 ```powershell
 $SubscriptionName = "MyTestSubscription"
-$SubscriptionId = "81b59010-dc55-45b7-89cd-5ca26db62472"
+$SubscriptionId = "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 $ClassicRunAsAccountCertifcateAssetName = "AzureClassicRunAsCertificate"
 $ClassicRunAsAccountConnectionFieldValues = @{"SubscriptionName" = $SubscriptionName; "SubscriptionId" = $SubscriptionId; "CertificateAssetName" = $ClassicRunAsAccountCertifcateAssetName}
 New-AzAutomationConnection -Name "Connection14" -ConnectionTypeName AzureClassicCertificate  -ConnectionFieldValues $ClassicRunAsAccountConnectionFieldValues -ResourceGroupName "ResourceGroup01" -AutomationAccountName "AutomationAccount01"
@@ -190,5 +190,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzAutomationConnection](./Get-AzAutomationConnection.md)
 
 [Remove-AzAutomationConnection](./Remove-AzAutomationConnection.md)
-
-

--- a/azps-12.5.0/Az.Automation/Set-AzAutomationConnectionFieldValue.md
+++ b/azps-12.5.0/Az.Automation/Set-AzAutomationConnectionFieldValue.md
@@ -28,7 +28,7 @@ The **Set-AzAutomationConnectionFieldValue** cmdlet modifies the value of a fiel
 
 ### Example 1: Change a field value in a connection
 ```powershell
-Set-AzAutomationConnectionFieldValue -Name "ContosoConnection" -ConnectionFieldName "SubscriptionID" -Value "b53ec456-3494-4847-8f2b-180901c51050" -ResourceGroupName "ResourceGroup01" -AutomationAccountName "AutomationAccount01"
+Set-AzAutomationConnectionFieldValue -Name "ContosoConnection" -ConnectionFieldName "SubscriptionID" -Value "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -ResourceGroupName "ResourceGroup01" -AutomationAccountName "AutomationAccount01"
 ```
 
 This command changes the subscription ID for the Azure connection named ContosoConnection in the Automation account named AutomationAccount01.
@@ -143,5 +143,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [New-AzAutomationConnection](./New-AzAutomationConnection.md)
-
-


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
