### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 6)

### DIFF
--- a/azps-12.5.0/Az.Blueprint/Get-AzBlueprint.md
+++ b/azps-12.5.0/Az.Blueprint/Get-AzBlueprint.md
@@ -72,8 +72,8 @@ Get-AzBlueprint
 
 ```output
 Name                 : PS-BlueprintDefinition
-Id                   : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprints/PS-BlueprintDefinition
-SubscriptionId       : 00000000-1111-0000-1111-000000000000
+Id                   : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprints/PS-BlueprintDefinition
+SubscriptionId       : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Versions             : {1.0}
 Description          : Powershell test blueprint
 TimeCreated          : 2019-02-01
@@ -105,13 +105,13 @@ Get the blueprint definitions within the specified management group.
 
 ### Example 3
 ```powershell
-Get-AzBlueprint -SubscriptionId "00000000-1111-0000-1111-000000000000"
+Get-AzBlueprint -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 ```
 
 ```output
 Name                 : PS-BlueprintDefinition
-Id                   : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprints/PS-BlueprintDefinition
-SubscriptionId       : 00000000-1111-0000-1111-000000000000
+Id                   : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprints/PS-BlueprintDefinition
+SubscriptionId       : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Versions             : {1.0}
 Description          : Powershell test blueprint
 TimeCreated          : 2019-02-01
@@ -124,7 +124,7 @@ Get the blueprint definitions within the specified subscription and the manageme
 
 ### Example 4
 ```powershell
-Get-AzBlueprint -SubscriptionId "00000000-1111-0000-1111-000000000000" -Name "myBlueprintName"
+Get-AzBlueprint -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Name "myBlueprintName"
 ```
 
 Get the blueprint definition with the given name within the specified subscription.

--- a/azps-12.5.0/Az.Blueprint/Get-AzBlueprintAssignment.md
+++ b/azps-12.5.0/Az.Blueprint/Get-AzBlueprintAssignment.md
@@ -45,13 +45,13 @@ Get one or more blueprint assignments. Blueprint assignments exist at the subscr
 
 ### Example 1
 ```powershell
-Get-AzBlueprintAssignment -SubscriptionId "00000000-1111-0000-1111-000000000000"
+Get-AzBlueprintAssignment -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 ```
 
 ```output
 Name              : Assignment-PS-BlueprintDefinition
-Id                : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprintAssignments/Assignment-PS-BlueprintDefinition
-Scope             : /subscriptions/00000000-1111-0000-1111-000000000000
+Id                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprintAssignments/Assignment-PS-BlueprintDefinition
+Scope             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 LastModified      : 2019-01-08
 LockMode          : AllResourcesReadOnly
 ProvisioningState : Succeeded
@@ -63,7 +63,7 @@ Get the blueprint assignments within the specified subscription.
 
 ### Example 2
 ```powershell
-Get-AzBlueprintAssignment -SubscriptionId "00000000-1111-0000-1111-000000000000" -Name "myAssignmentName"
+Get-AzBlueprintAssignment -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Name "myAssignmentName"
 ```
 
 Get the blueprint assignment with the given name within the specified subscription.

--- a/azps-12.5.0/Az.Blueprint/Import-AzBlueprintWithArtifact.md
+++ b/azps-12.5.0/Az.Blueprint/Import-AzBlueprintWithArtifact.md
@@ -27,7 +27,7 @@ Import a blueprint definition with its artifacts.
 
 ### Example 1
 ```powershell
-Import-AzBlueprintWithArtifact -Name MySimpleBlueprint -SubscriptionId 00000000-1111-0000-1111-000000000000 -InputPath  C:\Blueprints\SimpleBlueprint
+Import-AzBlueprintWithArtifact -Name MySimpleBlueprint -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -InputPath  C:\Blueprints\SimpleBlueprint
 ```
 
 Import a blueprint definition with its artifacts and save within a subscription.

--- a/azps-12.5.0/Az.Blueprint/New-AzBlueprint.md
+++ b/azps-12.5.0/Az.Blueprint/New-AzBlueprint.md
@@ -33,7 +33,7 @@ Create a new blueprint definition.
 
 ### Example 1
 ```powershell
-New-AzBlueprint -Name MyNewBlueprint -SubscriptionId 00000000-1111-0000-1111-000000000000 -BlueprintFile C:\Blueprint.json
+New-AzBlueprint -Name MyNewBlueprint -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -BlueprintFile C:\Blueprint.json
 ```
 
 ```output

--- a/azps-12.5.0/Az.Blueprint/New-AzBlueprintAssignment.md
+++ b/azps-12.5.0/Az.Blueprint/New-AzBlueprintAssignment.md
@@ -39,15 +39,15 @@ Assign a blueprint definition to a subscription.
 ```powershell
 $rg = @{ResourceGroup=@{name='storage_rg';location='eastus'}}
 $params = @{applytaganditsdefaultvalue_tagName="Department_Cost_Center"; applytaganditsdefaultvalue_tagValue="Contoso/RnD/Dev/986754"}
-$blueprintObject =  Get-AzBlueprint -SubscriptionId "00000000-1111-0000-1111-000000000000" -Name "myBlueprintName"
-$secureString = @{mySecureStringParam=@{keyVaultId='/subscriptions/00000000-1111-0000-1111-000000000000/rsourcegroups/myResourceGroup/providers/Microsoft.Keyvault/Vaults/myKeyVault';secretName='mySecret';secretVersion='1.0'}}
-New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "00000000-1111-0000-1111-000000000000" -Location "West US" -ResourceGroupParameter $rg -Parameter $params -SecureStringParameter $secureString
+$blueprintObject =  Get-AzBlueprint -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Name "myBlueprintName"
+$secureString = @{mySecureStringParam=@{keyVaultId='/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/rsourcegroups/myResourceGroup/providers/Microsoft.Keyvault/Vaults/myKeyVault';secretName='mySecret';secretVersion='1.0'}}
+New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Location "West US" -ResourceGroupParameter $rg -Parameter $params -SecureStringParameter $secureString
 ```
 
 ```output
 Name              : myAssignment
-Id                : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
-Scope             : /subscriptions/00000000-1111-0000-1111-000000000000
+Id                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
+Scope             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 LastModified      : 2019-01-08
 LockMode          : None
 ProvisioningState : Creating
@@ -59,28 +59,28 @@ Create a new blueprint assignment of the blueprint definition `$blueprintObject`
 
 ### Example 2
 ```powershell
-New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId 00000000-1111-0000-1111-000000000000 -Location "West US" -Parameter @{P1="v1"; P2="v2"} -Lock AllResourcesReadOnly
+New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -Location "West US" -Parameter @{P1="v1"; P2="v2"} -Lock AllResourcesReadOnly
 ```
 
 Create a new blueprint assignment of the blueprint definition `$blueprintObject` within the specified subscription using the defined parameter and resource group dictionary and configuring resource locking to **AllResources**. Defaults to using system-assigned identity.  The location defines the region for creating the managed identity.
 
 ### Example 3
 ```powershell
-New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId 00000000-1111-0000-1111-000000000000 -Location "West US" -Parameter @{P1="v1"; P2="v2"} -UserAssignedIdentity "/subscriptions/00000000-1111-0000-1111-000000000000/resourceGroups/my-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user-defined-identity"
+New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -Location "West US" -Parameter @{P1="v1"; P2="v2"} -UserAssignedIdentity "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/my-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user-defined-identity"
 ```
 
 Create a new blueprint assignment of the blueprint definition `$blueprintObject` within the specified subscription using the defined parameter and resource group dictionary using the specified user-assigned identity id.
 
 ### Example 4
 ```powershell
-$blueprintObject =  Get-AzBlueprint -SubscriptionId "00000000-1111-0000-1111-000000000000" -Name "myBlueprintName"
-New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "00000000-1111-0000-1111-000000000000" -AssignmentFile C:\myAssignmentfile.json
+$blueprintObject =  Get-AzBlueprint -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Name "myBlueprintName"
+New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -AssignmentFile C:\myAssignmentfile.json
 ```
 
 ```output
 Name              : myAssignment
-Id                : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
-Scope             : /subscriptions/00000000-1111-0000-1111-000000000000
+Id                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
+Scope             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 LastModified      : 2019-01-08
 LockMode          : None
 ProvisioningState : Creating
@@ -93,7 +93,7 @@ Create a blueprint assignment through an assignment file. The format of the assi
 ### Example 5
 ```powershell
 $blueprintObject =  Get-AzBlueprint -SubscriptionId "myManagementGroup" -Name "myBlueprintName"
-New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -ManagementGroupId "myManagementGroup" -SubscriptionId 00000000-1111-0000-1111-000000000000 -Location "West US" -Parameter @{P1="v1"; P2="v2"}
+New-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -ManagementGroupId "myManagementGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -Location "West US" -Parameter @{P1="v1"; P2="v2"}
 ```
 
 Create a new blueprint assignment of the blueprint definition `$blueprintObject` targeting the specified subscription within the specified management group using the defined parameter.

--- a/azps-12.5.0/Az.Blueprint/Publish-AzBlueprint.md
+++ b/azps-12.5.0/Az.Blueprint/Publish-AzBlueprint.md
@@ -32,7 +32,7 @@ Publish-AzBlueprint -Blueprint $bp -Version 1.0
 ```output
 Name           : SimpleBlueprint
 Id             : /subscriptions/{subscriptionId}/providers/Microsoft.Blueprint/blueprints/SimpleBlueprint/versions/1.0
-SubscriptionId : 00000000-1111-0000-1111-000000000000
+SubscriptionId : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Version        : 1.0
 Description    : My simple blueprint
 TimeCreated    : 2019-05-30

--- a/azps-12.5.0/Az.Blueprint/Remove-AzBlueprintAssignment.md
+++ b/azps-12.5.0/Az.Blueprint/Remove-AzBlueprintAssignment.md
@@ -39,7 +39,7 @@ Remove a blueprint that has been assigned to a subscription.
 
 ### Example 1
 ```powershell
-Remove-AzBlueprintAssignment -Name "myAssignment" -SubscriptionId "00000000-1111-0000-1111-000000000000" -Confirm
+Remove-AzBlueprintAssignment -Name "myAssignment" -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Confirm
 ```
 
 Remove the blueprint assignment specified by name from the specified subscription. The cmdlet will prompt for confirmation before executing the command.

--- a/azps-12.5.0/Az.Blueprint/Set-AzBlueprint.md
+++ b/azps-12.5.0/Az.Blueprint/Set-AzBlueprint.md
@@ -33,7 +33,7 @@ Update a blueprint definition and save it within the specified subscription or m
 
 ### Example 1
 ```powershell
-Set-AzBlueprint -Name MyBlueprint -SubscriptionId 00000000-1111-0000-1111-000000000000 -BlueprintFile C:\Blueprint.json
+Set-AzBlueprint -Name MyBlueprint -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -BlueprintFile C:\Blueprint.json
 ```
 
 ```output

--- a/azps-12.5.0/Az.Blueprint/Set-AzBlueprintAssignment.md
+++ b/azps-12.5.0/Az.Blueprint/Set-AzBlueprintAssignment.md
@@ -39,14 +39,14 @@ Update an existing blueprint assignment.
 ```powershell
 $rg = @{ResourceGroup=@{name='storage_rg';location='eastus'}}
 $params = @{applytaganditsdefaultvalue_tagName="Department_Cost_Center"; applytaganditsdefaultvalue_tagValue="Contoso/HR/Dev/0001"}
-$blueprintObject =  Get-AzBlueprint -SubscriptionId "00000000-1111-0000-1111-000000000000" -Name "myBlueprintName"
-Set-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "00000000-1111-0000-1111-000000000000" -Location "West US" -Parameter $params -ResourceGroupParameter $rg -SystemAssignedIdentity
+$blueprintObject =  Get-AzBlueprint -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Name "myBlueprintName"
+Set-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Location "West US" -Parameter $params -ResourceGroupParameter $rg -SystemAssignedIdentity
 ```
 
 ```output
 Name              : myAssignment
-Id                : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
-Scope             : /subscriptions/00000000-1111-0000-1111-000000000000
+Id                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
+Scope             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 LastModified      : 2019-01-08
 LockMode          : None
 ProvisioningState : Creating
@@ -58,14 +58,14 @@ Update an existing blueprint assignment of the blueprint definition `$blueprintO
 
 ### Example 2
 ```powershell
-$blueprintObject =  Get-AzBlueprint -SubscriptionId "00000000-1111-0000-1111-000000000000" -Name "myBlueprintName"
-Set-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "00000000-1111-0000-1111-000000000000" -AssignmentFile C:\myAssignmentfile.json
+$blueprintObject =  Get-AzBlueprint -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Name "myBlueprintName"
+Set-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -AssignmentFile C:\myAssignmentfile.json
 ```
 
 ```output
 Name              : myAssignment
-Id                : /subscriptions/00000000-1111-0000-1111-000000000000/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
-Scope             : /subscriptions/00000000-1111-0000-1111-000000000000
+Id                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Blueprint/blueprintAssignments/myAssignment
+Scope             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 LastModified      : 2019-01-08
 LockMode          : None
 ProvisioningState : Creating
@@ -78,7 +78,7 @@ Update an existing blueprint assignment through an assignment file. The format o
 ### Example 3
 ```powershell
 $blueprintObject =  Get-AzBlueprint -ManagementGroupId "myManagementGroup" -Name "myBlueprintName"
-Set-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -ManagementGroupId "myManagementGroup" -SubscriptionId 00000000-1111-0000-1111-000000000000 -Location "West US" -Parameter @{P1="v1"; P2="v2"}
+Set-AzBlueprintAssignment -Name "myAssignment" -Blueprint $blueprintObject -ManagementGroupId "myManagementGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -Location "West US" -Parameter @{P1="v1"; P2="v2"}
 ```
 
 Update an existing blueprint assignment of the blueprint definition `$blueprintObject` targeting the specified subscription within the specified management group using the defined parameter.


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
