### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 25)

### DIFF
--- a/azps-12.5.0/Az.LogicApp/Get-AzLogicAppRunHistory.md
+++ b/azps-12.5.0/Az.LogicApp/Get-AzLogicAppRunHistory.md
@@ -40,7 +40,7 @@ Get-AzLogicAppRunHistory -ResourceGroupName "Resourcegroup11" -Name "LogicApp03"
 ```
 
 ```output
-CorrelationId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+CorrelationId    : aaaa0000-bb11-2222-33cc-444444dddddd
 EndTime          : 1/13/2016 2:46:55 PM
 Error            : {code, message}
 Name             : 08587489104702792076
@@ -51,7 +51,7 @@ TriggerName      :
 LogicAppName     : LogicApp03
 LogicAppVersion  : 08587489107859952540
 
-CorrelationId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+CorrelationId    : aaaa0000-bb11-2222-33cc-444444dddddd
 EndTime          : 1/13/2016 2:42:56 PM
 Error            : {code, message}
 Name             : 08587489107100664541
@@ -72,7 +72,7 @@ Get-AzLogicAppRunHistory -ResourceGroupName "Resourcegroup11" -Name "LogicApp03"
 ```
 
 ```output
-CorrelationId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+CorrelationId    : aaaa0000-bb11-2222-33cc-444444dddddd
 EndTime          : 1/13/2016 2:46:55 PM
 Error            : {code, message}
 Name             : 08587489104702792076


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
