### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 26)

### DIFF
--- a/azps-12.5.0/Az.Maintenance/Get-AzApplyUpdate.md
+++ b/azps-12.5.0/Az.Maintenance/Get-AzApplyUpdate.md
@@ -32,9 +32,9 @@ Get-AzApplyUpdate -ResourceGroupName smdtest$region -ResourceParentType hostGrou
 
 ```output
 Status         : InProgress
-ResourceId     : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2
+ResourceId     : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2
 LastUpdateTime : 11/8/2019 9:39:01 AM
-Id             : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/applyUpdates/default
+Id             : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/applyUpdates/default
 Name           : default
 Type           : Microsoft.Maintenance/applyUpdates
 ```

--- a/azps-12.5.0/Az.Maintenance/Get-AzConfigurationAssignment.md
+++ b/azps-12.5.0/Az.Maintenance/Get-AzConfigurationAssignment.md
@@ -32,9 +32,9 @@ Get-AzConfigurationAssignment -ResourceGroupName smdtestwestus2 -ResourceParentT
 ```
 
 ```output
-MaintenanceConfigurationId : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/ps1/providers/Microsoft.Maintenance/maintenanceConfigurations/ps2
+MaintenanceConfigurationId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/ps1/providers/Microsoft.Maintenance/maintenanceConfigurations/ps2
 Id                         :
-/subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/configurationAssignments/ps2
+/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/configurationAssignments/ps2
 Name                       : ps2
 Type                       : Microsoft.Maintenance/configurationAssignments
 ```
@@ -47,8 +47,8 @@ Get-AzConfigurationAssignment -ResourceGroupName 'rgtestwestus2' -ProviderName M
 ```
 
 ```output
-MaintenanceConfigurationId : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/maintenanceconfigurations/providers/microsoft.maintenance/maintenanceconfigurations/dynamicfiltertag
-ResourceId                 : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/rgtestwestus2/providers/microsoft.hybridcompute/machines/laptop-abcdefg
+MaintenanceConfigurationId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/maintenanceconfigurations/providers/microsoft.maintenance/maintenanceconfigurations/dynamicfiltertag
+ResourceId                 : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/rgtestwestus2/providers/microsoft.hybridcompute/machines/laptop-abcdefg
 Id                         : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa747/resourcegroups/rgtestwestus2/providers/Microsoft.HybridCompute/machines/LAPTOP-ABCDEFG/providers/Microsoft.Maintenance/configurationAssignments/pphsfbx2qur7k-azpolicy
 Name                       : pphsfbx2qur7k-azpolicy
 Type                       : Microsoft.Maintenance/configurationAssignments
@@ -62,8 +62,8 @@ Get-AzConfigurationAssignment -ResourceGroupName 'ArcMachines' -ProviderName Mic
 ```
 
 ```output
-MaintenanceConfigurationId : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/maintenanceconfigurations/providers/microsoft.maintenance/maintenanceconfigurations/dynamicfiltertag
-ResourceId                 : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/arcmachines/providers/microsoft.hybridcompute/machines/laptop-ivmi31g2
+MaintenanceConfigurationId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/maintenanceconfigurations/providers/microsoft.maintenance/maintenanceconfigurations/dynamicfiltertag
+ResourceId                 : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/arcmachines/providers/microsoft.hybridcompute/machines/laptop-ivmi31g2
 Id                         : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa747/resourcegroups/arcmachines/providers/Microsoft.HybridCompute/machines/LAPTOP-IVMI31G2/providers/Microsoft.Maintenance/configurationAssignments/pphsfbx2qur7k-azpolicy
 Name                       : pphsfbx2qur7k-azpolicy
 Type                       : Microsoft.Maintenance/configurationAssignments

--- a/azps-12.5.0/Az.Maintenance/Get-AzMaintenanceUpdate.md
+++ b/azps-12.5.0/Az.Maintenance/Get-AzMaintenanceUpdate.md
@@ -36,7 +36,7 @@ ImpactType          : Freeze
 Status              : Pending
 ImpactDurationInSec : 9
 NotBefore           : 1/24/2020 5:11:41 AM
-ResourceId          : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2
+ResourceId          : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2
 ```
 
 Get pending maintenance updates to resource.

--- a/azps-12.5.0/Az.Maintenance/New-AzApplyUpdate.md
+++ b/azps-12.5.0/Az.Maintenance/New-AzApplyUpdate.md
@@ -33,10 +33,10 @@ New-AzApplyUpdate -ResourceGroupName smdtest$region -ResourceParentType hostGrou
 
 ```output
 Status         : InProgress
-ResourceId     : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2
+ResourceId     : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2
 LastUpdateTime : 11/8/2019 9:39:01 AM
 Id             :
-/subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/applyUpdates/cbd4c97d-2011-4fa3-9df1-525f97e74eac
+/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/applyUpdates/cbd4c97d-2011-4fa3-9df1-525f97e74eac
 Name           : cbd4c97d-2011-4fa3-9df1-525f97e74eac
 Type           : Microsoft.Maintenance/applyUpdates
 ```

--- a/azps-12.5.0/Az.Maintenance/New-AzConfigurationAssignment.md
+++ b/azps-12.5.0/Az.Maintenance/New-AzConfigurationAssignment.md
@@ -36,7 +36,7 @@ New-AzConfigurationAssignment -ResourceGroupName smdtest$location -ResourceParen
 ```output
 Location                   : westus2
 MaintenanceConfigurationId : /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/ps1/providers/Microsoft.Maintenance/maintenanceConfigurations/ps2
-ResourceId                 : 7b32ed22-dc7b-4a17-9c42-36c024f4c9f9
+ResourceId                 : a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1
 Id                         :
 /subscriptions/42c974dd-2c03-4f1b-96ad-b07f050aaa74/resourcegroups/smdtestwestus2/providers/Microsoft.Compute/hostGroups/smddhgwestus2/hosts/smddhwestus2/providers/Microsoft.Maintenance/configurationAssignments/ps2
 Name                       : ps2
@@ -47,14 +47,14 @@ Register maintenance configuration for dedicated host.
 
 ### Example 2
 ```powershell
-New-AzConfigurationAssignment -ConfigurationAssignmentName configAssignmentName -MaintenanceConfigurationId /subscriptions/eee2cef4-bc47-4278-b4f8-cfc65f25dfd8/resourceGroups/AUMDemov01/providers/Microsoft.Maintenance/maintenanceConfigurations/kachavan-prepost01  -FilterLocation eastus2euap,centraluseuap  -FilterOsType Windows,Linux -FilterTag '{"tagKey1" : ["tagKey1Value1", "tagKey1Value2"], "tagKey2" : ["tagKey2Value1", "tagKey2Value2", "tagKey2Value3"] }' -FilterOperator "Any" -Location global
+New-AzConfigurationAssignment -ConfigurationAssignmentName configAssignmentName -MaintenanceConfigurationId /subscriptions/b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2/resourceGroups/AUMDemov01/providers/Microsoft.Maintenance/maintenanceConfigurations/kachavan-prepost01  -FilterLocation eastus2euap,centraluseuap  -FilterOsType Windows,Linux -FilterTag '{"tagKey1" : ["tagKey1Value1", "tagKey1Value2"], "tagKey2" : ["tagKey2Value1", "tagKey2Value2", "tagKey2Value3"] }' -FilterOperator "Any" -Location global
 ```
 
 ```output
 Location                   : global
-MaintenanceConfigurationId : /subscriptions/eee2cef4-bc47-4278-b4f8-cfc65f25dfd8/resourceGroups/AUMDemov01/providers/Microsoft.Maintenance/maintenanceConfigurations/kachavan-prepost01
-ResourceId                 : /subscriptions/eee2cef4-bc47-4278-b4f8-cfc65f25dfd8
-Id                         : /subscriptions/eee2cef4-bc47-4278-b4f8-cfc65f25dfd8/providers/microsoft.maintenance/configurationassignments/configassignmentname
+MaintenanceConfigurationId : /subscriptions/b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2/resourceGroups/AUMDemov01/providers/Microsoft.Maintenance/maintenanceConfigurations/kachavan-prepost01
+ResourceId                 : /subscriptions/b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2
+Id                         : /subscriptions/b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2/providers/microsoft.maintenance/configurationassignments/configassignmentname
 Name                       : configassignmentname
 Type                       : microsoft.maintenance/configurationassignments
 FilterTag                  : {"tagKey1":["tagKey1Value1","tagKey1Value2"],"tagKey2":["tagKey2Value1","tagKey2Value2","tagKey2Value3"]}


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
