### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 27)

### DIFF
--- a/azps-12.5.0/Az.ManagementPartner/Get-AzManagementPartner.md
+++ b/azps-12.5.0/Az.ManagementPartner/Get-AzManagementPartner.md
@@ -31,8 +31,8 @@ Get-AzManagementPartner
 ```output
 PartnerId   : 4977985
 PartnerName : Test_Test_DPORTest
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
-ObjectId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
+ObjectId    : ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0
 State       : Active
 ```
 
@@ -46,8 +46,8 @@ Get-AzManagementPartner -PartnerId 4977985
 ```output
 PartnerId   : 4977985
 PartnerName : Test_Test_DPORTest
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
-ObjectId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
+ObjectId    : ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0
 State       : Active
 ```
 

--- a/azps-12.5.0/Az.ManagementPartner/New-AzManagementPartner.md
+++ b/azps-12.5.0/Az.ManagementPartner/New-AzManagementPartner.md
@@ -32,8 +32,8 @@ New-AzManagementPartner -PartnerId 4977985
 ```output
 PartnerId   : 4977985
 PartnerName : Test_Test_DPORTest
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
-ObjectId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
+ObjectId    : ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0
 State       : Active
 ```
 

--- a/azps-12.5.0/Az.ManagementPartner/Update-AzManagementPartner.md
+++ b/azps-12.5.0/Az.ManagementPartner/Update-AzManagementPartner.md
@@ -32,8 +32,8 @@ Update-AzManagementPartner -PartnerId 4977985
 ```output
 PartnerId   : 4977985
 PartnerName : Test_Test_DPORTest
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
-ObjectId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
+ObjectId    : ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0
 State       : Active
 ```
 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
