### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 31)

### DIFF
--- a/azps-12.5.0/Az.Network/Get-AzNetworkManagerConnectivityConfiguration.md
+++ b/azps-12.5.0/Az.Network/Get-AzNetworkManagerConnectivityConfiguration.md
@@ -38,7 +38,7 @@ Get-AzNetworkManagerConnectivityConfiguration -ResourceGroupName "psResourceGrou
 
 ```output
 ConnectivityTopology  : HubAndSpoke
-Hubs                  : {/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
+Hubs                  : {/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
 DeleteExistingPeering : True
 IsGlobal              : False
 AppliesToGroups       : {/subscriptions/f0dc2b34-dfad-40e4-83e0-2309fed8d00b/resourceGroups/psResourceGroup/providers/Microsoft.Network/networkManagers/psNetworkManager/networkGroups/psNetworkGroup,
@@ -61,7 +61,7 @@ AppliesToGroupsText   : [
                         ]
 HubsText              : [
                           {
-                            "ResourceId": "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
+                            "ResourceId": "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
                             "ResourceType": "Microsoft.Network/virtualNetworks"
                           }
                         ]
@@ -92,7 +92,7 @@ Get-AzNetworkManagerConnectivityConfiguration -ResourceGroupName "psResourceGrou
 
 ```output
 ConnectivityTopology  : HubAndSpoke
-Hubs                  : {/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
+Hubs                  : {/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
 DeleteExistingPeering : True
 IsGlobal              : False
 AppliesToGroups       : {/subscriptions/f0dc2b34-dfad-40e4-83e0-2309fed8d00b/resourceGroups/psResourceGroup/providers/Microsoft.Network/networkManagers/psNetworkManager/networkGroups/psNetworkGroup,
@@ -115,7 +115,7 @@ AppliesToGroupsText   : [
                         ]
 HubsText              : [
                           {
-                            "ResourceId": "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
+                            "ResourceId": "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
                             "ResourceType": "Microsoft.Network/virtualNetworks"
                           }
                         ]

--- a/azps-12.5.0/Az.Network/Get-AzNetworkManagerScopeConnection.md
+++ b/azps-12.5.0/Az.Network/Get-AzNetworkManagerScopeConnection.md
@@ -66,8 +66,8 @@ Get-AzNetworkManagerScopeConnection -ResourceGroupName "psResourceGroup" -Networ
 ```
 
 ```output
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
-ResourceId        : /subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
+ResourceId        : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1
 ConnectionState   : Pending
 DisplayName       :
 Description       : SampleDescription
@@ -86,7 +86,7 @@ Name              : subConnection
 Etag              :
 Id                : /subscriptions/f0dc2b34-dfad-40e4-83e0-2309fed8d00b/resourceGroups/psResourceGroup/providers/Microsoft.Network/networkManagers/psNetworkManager/scopeConnections/subConnection
 
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 ResourceId        : /providers/Microsoft.Management/managementGroups/newMG
 ConnectionState   : Pending
 DisplayName       :

--- a/azps-12.5.0/Az.Network/New-AzNetworkManagerConnectivityConfiguration.md
+++ b/azps-12.5.0/Az.Network/New-AzNetworkManagerConnectivityConfiguration.md
@@ -32,14 +32,14 @@ The **New-AzNetworkManagerConnectivityConfiguration** cmdlet creates a network m
 $connectivityGroupItem = New-AzNetworkManagerConnectivityGroupItem -NetworkGroupId "/subscriptions/f0dc2b34-dfad-40e4-83e0-2309fed8d00b/resourceGroups/psResourceGroup/providers/Microsoft.Network/networkManagers/psNetworkManager/networkGroups/psNetworkGroup"
 $connectivityGroup  = @($connectivityGroupItem)  
 
-$hub = New-AzNetworkManagerHub -ResourceId "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub" -ResourceType "Microsoft.Network/virtualNetworks" 
+$hub = New-AzNetworkManagerHub -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub" -ResourceType "Microsoft.Network/virtualNetworks" 
 $hubList = @($hub)
 New-AzNetworkManagerConnectivityConfiguration -ResourceGroupName psResourceGroup -Name "psConnectivityConfig" -NetworkManagerName psNetworkManager -ConnectivityTopology "HubAndSpoke" -Hub $hublist -AppliesToGroup $connectivityGroup -DeleteExistingPeering
 ```
 
 ```output
 ConnectivityTopology  : HubAndSpoke
-Hubs                  : {/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
+Hubs                  : {/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
 DeleteExistingPeering : True
 IsGlobal              : False
 AppliesToGroups       : {/subscriptions/f0dc2b34-dfad-40e4-83e0-2309fed8d00b/resourceGroups/psResourceGroup/providers/Microsoft.Network/networkManagers/psNetworkManager/networkGroups/psNetworkGroup}
@@ -53,7 +53,7 @@ AppliesToGroupsText   : [
                         ]
 HubsText              : [
                           {
-                            "ResourceId": "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
+                            "ResourceId": "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
                             "ResourceType": "Microsoft.Network/virtualNetworks"
                           }
                         ]

--- a/azps-12.5.0/Az.Network/New-AzNetworkManagerScopeConnection.md
+++ b/azps-12.5.0/Az.Network/New-AzNetworkManagerScopeConnection.md
@@ -27,12 +27,12 @@ The **New-AzNetworkManagerScopeConnection** cmdlet creates a scope connection.
 
 ### Example 1
 ```powershell
-New-AzNetworkManagerScopeConnection -ResourceGroupName psResourceGroup -NetworkManagerName psNetworkManager -Name "subConnection" -TenantId "00001111-aaaa-2222-bbbb-3333cccc4444" -ResourceId "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884" -Description "SampleDescription"
+New-AzNetworkManagerScopeConnection -ResourceGroupName psResourceGroup -NetworkManagerName psNetworkManager -Name "subConnection" -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee" -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -Description "SampleDescription"
 ```
 
 ```output
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
-ResourceId        : /subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
+ResourceId        : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1
 ConnectionState   : Pending
 DisplayName       :
 Description       : SampleDescription
@@ -56,11 +56,11 @@ Creates a scope connection to a cross-tenant subscription.
 
 ### Example 2
 ```powershell
-New-AzNetworkManagerScopeConnection -ResourceGroupName psResourceGroup -NetworkManagerName psNetworkManager -Name "mgConnection" -TenantId "00001111-aaaa-2222-bbbb-3333cccc4444" -ResourceId "/providers/Microsoft.Management/managementGroups/newMG" -Description "SampleDescription"
+New-AzNetworkManagerScopeConnection -ResourceGroupName psResourceGroup -NetworkManagerName psNetworkManager -Name "mgConnection" -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee" -ResourceId "/providers/Microsoft.Management/managementGroups/newMG" -Description "SampleDescription"
 ```
 
 ```output
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 ResourceId        : /providers/Microsoft.Management/managementGroups/newMG
 ConnectionState   : Pending
 DisplayName       :

--- a/azps-12.5.0/Az.Network/New-AzNetworkManagerStaticMember.md
+++ b/azps-12.5.0/Az.Network/New-AzNetworkManagerStaticMember.md
@@ -27,12 +27,12 @@ The **New-AzNetworkManagerStaticMember** cmdlet creates a network manager static
 
 ### Example 1
 ```powershell
-$vnetId = "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnet"
+$vnetId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnet"
 New-AzNetworkManagerStaticMember -ResourceGroupName "psResourceGroup" -NetworkManagerName "psNetworkManager" -NetworkGroupName "psNetworkGroup" -Name "psStaticMember" -ResourceId $vnetId
 ```
 
 ```output
-ResourceId        : /subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnet
+ResourceId        : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnet
 DisplayName       :
 Description       :
 Type              : Microsoft.Network/networkManagers/networkGroups/staticMembers

--- a/azps-12.5.0/Az.Network/New-AzNetworkWatcherFlowLog.md
+++ b/azps-12.5.0/Az.Network/New-AzNetworkWatcherFlowLog.md
@@ -115,7 +115,7 @@ IdentityText               : {
                                "Type": "UserAssigned",
                                "UserAssignedIdentities": {
                                  "/subscriptions/af15e575-f948-49ac-bce0-252d028e9379/resourcegroups/mejaRGEastUS2EUAP/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mejaid2": {
-                                    "PrincipalId": "00001111-aaaa-2222-bbbb-3333cccc4444",
+                                    "PrincipalId": "aaaaaaaa-bbbb-cccc-1111-222222222222",
                                     "ClientId": "00001111-aaaa-2222-bbbb-3333cccc4444"
                                   }
                                 }

--- a/azps-12.5.0/Az.Network/Set-AzNetworkManagerConnectivityConfiguration.md
+++ b/azps-12.5.0/Az.Network/Set-AzNetworkManagerConnectivityConfiguration.md
@@ -38,7 +38,7 @@ Set-AzNetworkManagerConnectivityConfiguration -InputObject $ConnectivityConfigur
 
 ```output
 ConnectivityTopology  : HubAndSpoke
-Hubs                  : {/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
+Hubs                  : {/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub}
 DeleteExistingPeering : True
 IsGlobal              : False
 AppliesToGroups       : {/subscriptions/f0dc2b34-dfad-40e4-83e0-2309fed8d00b/resourceGroups/psResourceGroup/providers/Microsoft.Network/networkManagers/psNetworkManager/networkGroups/psNetworkGroup,
@@ -61,7 +61,7 @@ AppliesToGroupsText   : [
                         ]
 HubsText              : [
                           {
-                            "ResourceId": "/subscriptions/0fd190fa-dd1c-4724-b7f6-c5cc3ba5c884/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
+                            "ResourceId": "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/jaredgorthy-PowerShellTestResources/providers/Microsoft.Network/virtualNetworks/powerShellTestVnetHub",
                             "ResourceType": "Microsoft.Network/virtualNetworks"
                           }
                         ]

--- a/azps-12.5.0/Az.Network/Set-AzNetworkManagerScopeConnection.md
+++ b/azps-12.5.0/Az.Network/Set-AzNetworkManagerScopeConnection.md
@@ -32,7 +32,7 @@ Set-AzNetworkManagerScopeConnection -InputObject $scopeConnection
 ```
 
 ```output
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 ResourceId        : /providers/Microsoft.Management/managementGroups/newMG
 ConnectionState   : Pending
 DisplayName       :


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
