### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 32)

### DIFF
--- a/azps-12.5.0/Az.NewRelic/Get-AzNewRelicPlan.md
+++ b/azps-12.5.0/Az.NewRelic/Get-AzNewRelicPlan.md
@@ -26,7 +26,7 @@ List plans data
 
 ### Example 1: List plans data associated with specified organization
 ```powershell
-Get-AzNewRelicPlan -SubscriptionId 00001111-aaaa-2222-bbbb-3333cccc4444 -OrganizationId 11111111-2222-3333-4444-123456789104
+Get-AzNewRelicPlan -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -OrganizationId 00aa00aa-bb11-cc22-dd33-44ee44ee44ee
 ```
 
 ```output
@@ -39,7 +39,7 @@ List plans data associated with specified Organization Id
 
 ### Example 2: Link plans account with specified organization in different subscription
 ```powershell
-Get-AzNewRelicPlan -SubscriptionId 00001111-aaaa-2222-bbbb-3333cccc4444 -OrganizationId 11111111-2222-3333-4444-123456789104 -AccountId 1234567
+Get-AzNewRelicPlan -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -OrganizationId 00aa00aa-bb11-cc22-dd33-44ee44ee44ee -AccountId 1234567
 ```
 
 Link plans account with specified organization in different subscription

--- a/azps-12.5.0/Az.NewRelic/Update-AzNewRelicMonitoredSubscription.md
+++ b/azps-12.5.0/Az.NewRelic/Update-AzNewRelicMonitoredSubscription.md
@@ -54,7 +54,7 @@ MonitoredSubscriptionList : {{
                               "tagRules": {
                                 "provisioningState": "Accepted"
                               },
-                              "subscriptionId": "11111111-2222-3333-4444-123456789101",
+                              "subscriptionId": "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e",
                               "status": "Active"
                             }}
 Name                      : default


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
