### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 35)

### DIFF
--- a/azps-12.5.0/Az.Purview/Add-AzPurviewAccountRootCollectionAdmin.md
+++ b/azps-12.5.0/Az.Purview/Add-AzPurviewAccountRootCollectionAdmin.md
@@ -35,7 +35,7 @@ Add the administrator for root collection associated with this account.
 
 ### Example 1: Add the administrator for root collection
 ```powershell
-Add-AzPurviewAccountRootCollectionAdmin -AccountName test-pa -ResourceGroupName test-rg -ObjectId xxxxxxxx-5be9-4f43-abd2-04561777c8b0
+Add-AzPurviewAccountRootCollectionAdmin -AccountName test-pa -ResourceGroupName test-rg -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
 Add the administrator for root collection associated with the account named 'test-pa'.
@@ -43,7 +43,7 @@ Add the administrator for root collection associated with the account named 'tes
 ### Example 2: Add the administrator for root collection by InputObject
 ```powershell
 $got = Get-AzPurviewAccount -Name test-pa -ResourceGroupName test-rg
-Add-AzPurviewAccountRootCollectionAdmin -InputObject $got -ObjectId xxxxxxxx-5be9-4f43-abd2-04561777c8b0
+Add-AzPurviewAccountRootCollectionAdmin -InputObject $got -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
 Add the administrator for root collection associated with the account named 'test-pa' by InputObject.

--- a/azps-12.5.0/Az.Purview/Update-AzPurviewAccount.md
+++ b/azps-12.5.0/Az.Purview/Update-AzPurviewAccount.md
@@ -51,12 +51,12 @@ FriendlyName                     : test-pa
 Id                               : /subscriptions/xxxxxxxx-1bf0-4dda-aec3-cb9272f09590/resourceGroups/test-rg/providers/Microsoft.Purview/a 
                                    ccounts/test-pa
 Identity                         : {
-                                     "principalId": "xxxxxxxx-7956-4978-87e8-9ddd82cfe2b7",
-                                     "tenantId": "xxxxxxxx-38d6-4fb2-bad9-b7b93a3e9c5a",
+                                     "principalId": "aaaaaaaa-bbbb-cccc-1111-222222222222",
+                                     "tenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
                                      "type": "SystemAssigned"
                                    }
-IdentityPrincipalId              : xxxxxxxx-7956-4978-87e8-9ddd82cfe2b7
-IdentityTenantId                 : xxxxxxxx-38d6-4fb2-bad9-b7b93a3e9c5a
+IdentityPrincipalId              : aaaaaaaa-bbbb-cccc-1111-222222222222
+IdentityTenantId                 : aaaabbbb-0000-cccc-1111-dddd2222eeee
 IdentityType                     : SystemAssigned
 Location                         : eastus
 ManagedResourceEventHubNamespace : /subscriptions/xxxxxxxx-1bf0-4dda-aec3-cb9272f09590/resourceGroups/managed-rg-bbcpgdj/providers/Microso 
@@ -112,12 +112,12 @@ FriendlyName                     : test-pa
 Id                               : /subscriptions/xxxxxxxx-1bf0-4dda-aec3-cb9272f09590/resourceGroups/test-rg/providers/Microsoft.Purview/a 
                                    ccounts/test-pa
 Identity                         : {
-                                     "principalId": "xxxxxxxx-7956-4978-87e8-9ddd82cfe2b7",
-                                     "tenantId": "xxxxxxxx-38d6-4fb2-bad9-b7b93a3e9c5a",
+                                     "principalId": "aaaaaaaa-bbbb-cccc-1111-222222222222",
+                                     "tenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
                                      "type": "SystemAssigned"
                                    }
-IdentityPrincipalId              : xxxxxxxx-7956-4978-87e8-9ddd82cfe2b7
-IdentityTenantId                 : xxxxxxxx-38d6-4fb2-bad9-b7b93a3e9c5a
+IdentityPrincipalId              : aaaaaaaa-bbbb-cccc-1111-222222222222
+IdentityTenantId                 : aaaabbbb-0000-cccc-1111-dddd2222eeee
 IdentityType                     : SystemAssigned
 Location                         : eastus
 ManagedResourceEventHubNamespace : /subscriptions/xxxxxxxx-1bf0-4dda-aec3-cb9272f09590/resourceGroups/managed-rg-bbcpgdj/providers/Microso 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
