### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 39)

### DIFF
--- a/azps-12.5.0/Az.Reservations/Get-AzReservationCatalog.md
+++ b/azps-12.5.0/Az.Reservations/Get-AzReservationCatalog.md
@@ -37,7 +37,7 @@ Get the regions and skus that are available for RI purchase for the specified Az
 
 ### Example 1: Get the list of reserved resource type skus with location
 ```powershell
-Get-AzReservationCatalog -SubscriptionId "10000000-aaaa-bbbb-cccc-100000000001" -Location "westus" -ReservedResourceType "VirtualMachine"
+Get-AzReservationCatalog -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Location "westus" -ReservedResourceType "VirtualMachine"
 ```
 
 ```output
@@ -58,7 +58,7 @@ This command gets a catlog of reserved resource type skus with location
 
 ### Example 2: Get the list of reserved resource type skus without location
 ```powershell
-Get-AzReservationCatalog -SubscriptionId "10000000-aaaa-bbbb-cccc-100000000001" -ReservedResourceType "SuseLinux"
+Get-AzReservationCatalog -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -ReservedResourceType "SuseLinux"
 ```
 
 ```output
@@ -86,7 +86,7 @@ This command gets a catlog of reserved resource type skus without location
 
 ### Example 3: Get the list of eligible 3pp reserved resource type skus with publisher id, offer id, plan id
 ```powershell
-Get-AzReservationCatalog -SubscriptionId "10000000-aaaa-bbbb-cccc-100000000001" -ReservedResourceType "VirtualMachineSoftware" -PublisherId canonical -OfferId 0001-com-ubuntu-pro-xenial -PlanId pro-16_04-lts
+Get-AzReservationCatalog -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -ReservedResourceType "VirtualMachineSoftware" -PublisherId canonical -OfferId 0001-com-ubuntu-pro-xenial -PlanId pro-16_04-lts
 ```
 
 ```output

--- a/azps-12.5.0/Az.Reservations/Get-AzReservationOrderId.md
+++ b/azps-12.5.0/Az.Reservations/Get-AzReservationOrderId.md
@@ -33,11 +33,11 @@ Get applicable `Reservation`s that are applied to this subscription or a resourc
 
 ### Example 1: Get list of applicable ReservationOrder Ids.
 ```powershell
-Get-AzReservationOrderId -SubscriptionId '10000000-aaaa-bbbb-cccc-100000000005'
+Get-AzReservationOrderId -SubscriptionId 'aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e'
 ```
 
 ```output
-Id                         : /subscriptions/10000000-aaaa-bbbb-cccc-100000000005/providers/microsoft.capacity/AppliedReservations/default
+Id                         : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/microsoft.capacity/AppliedReservations/default
 Name                       : default
 ReservationOrderIdNextLink : 
 ReservationOrderIdValue    : {/providers/Microsoft.Capacity/reservationorders/7c6192be-7543-40c3-93e1-3d7f0b15203f, 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
