### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 40)

### DIFF
--- a/azps-12.5.0/Az.ResourceGraph/Search-AzGraph.md
+++ b/azps-12.5.0/Az.ResourceGraph/Search-AzGraph.md
@@ -46,19 +46,19 @@ Search-AzGraph "project id, name, type, location, tags" -First 3
 ```
 
 ```output
-id         : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
+id         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
 name       : nt
 type       : microsoft.compute/virtualmachinescalesets
 location   : eastus
 tags       : @{resourceType=Service Fabric; clusterName=gov-art-int-nt-a}
-ResourceId : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
+ResourceId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
 
-id         : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
+id         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
 name       : egtopic-1
 type       : microsoft.eventgrid/topics
 location   : westus2
 tags       :
-ResourceId : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
+ResourceId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
 ```
 
 Simple resources query requesting a subset of resource fields.
@@ -85,17 +85,17 @@ Search-AzGraph -Query "project id, name, type, location" -SkipToken $response.Sk
 ```
 
 ```output
-id         : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/test/providers/Microsoft.Network/networkInterfaces/17ni
+id         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/test/providers/Microsoft.Network/networkInterfaces/17ni
 name       : 17ni
 type       : microsoft.network/networkinterfaces
 location   : westeurope
-ResourceId : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/test/providers/Microsoft.Network/networkInterfaces/17ni
+ResourceId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/test/providers/Microsoft.Network/networkInterfaces/17ni
 
-id         : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/test/providers/Microsoft.Network/networkSecurityGroups/17nsg
+id         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/test/providers/Microsoft.Network/networkSecurityGroups/17nsg
 name       : 17nsg
 type       : microsoft.network/networksecuritygroups
 location   : westeurope
-ResourceId : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/test/providers/Microsoft.Network/networkSecurityGroups/17nsg
+ResourceId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/test/providers/Microsoft.Network/networkSecurityGroups/17nsg
 ```
 
 A query with the skip token passed from the previous query results. Please note that keeping id in the results is mandatory to get back a skip token.
@@ -106,19 +106,19 @@ Search-AzGraph -Query "project id, name, type, location, tags" -First 2 -Managem
 ```
 
 ```output
-id         : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
+id         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
 name       : nt
 type       : microsoft.compute/virtualmachinescalesets
 location   : eastus
 tags       : @{resourceType=Service Fabric; clusterName=gov-art-int-nt-a}
-ResourceId : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
+ResourceId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.Compute/virtualMachineScaleSets/nt
 
-id         : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
+id         : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
 name       : egtopic-1
 type       : microsoft.eventgrid/topics
 location   : westus2
 tags       :
-ResourceId : /subscriptions/1ef51df4-f8a9-4b69-9919-1ef51df4eff6/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
+ResourceId : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Service-INT-a/providers/Microsoft.EventGrid/topics/egtopic-1
 ```
 
 A query scoped to the management group that allows the query to succeed with partial scope result if MyManagementGroupId has more than N subscriptions underneath.


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
