### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 41)

### DIFF
--- a/azps-12.5.0/Az.Resources/Add-AzADAppPermission.md
+++ b/azps-12.5.0/Az.Resources/Add-AzADAppPermission.md
@@ -43,17 +43,17 @@ User needs to grant consent via Azure Portal if the permission requires admin co
 
 ### Example 1: Add API Permission
 ```powershell
-Add-AzADAppPermission -ObjectId 9cc74d5e-1162-4b90-8696-65f3d6a3f7d0 -ApiId 00001111-aaaa-2222-bbbb-3333cccc4444 -PermissionId 5f8c59db-677d-491f-a6b8-5f174b11ec1d
+Add-AzADAppPermission -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -ApiId 00001111-aaaa-2222-bbbb-3333cccc4444 -PermissionId 5f8c59db-677d-491f-a6b8-5f174b11ec1d
 ```
 
-Add delegated permission "Group.Read.All" of Microsoft Graph API to AD Application (9cc74d5e-1162-4b90-8696-65f3d6a3f7d0)
+Add delegated permission "Group.Read.All" of Microsoft Graph API to AD Application (aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb)
 
 ### Example 2: Add API Permission
 ```powershell
-Add-AzADAppPermission -ObjectId 9cc74d5e-1162-4b90-8696-65f3d6a3f7d0 -ApiId 00001111-aaaa-2222-bbbb-3333cccc4444 -PermissionId 1138cb37-bd11-4084-a2b7-9f71582aeddb -Type Role
+Add-AzADAppPermission -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -ApiId 00001111-aaaa-2222-bbbb-3333cccc4444 -PermissionId 1138cb37-bd11-4084-a2b7-9f71582aeddb -Type Role
 ```
 
-Add application permission "Device.ReadWrite.All" of Microsoft Graph API to AD Application (9cc74d5e-1162-4b90-8696-65f3d6a3f7d0)
+Add application permission "Device.ReadWrite.All" of Microsoft Graph API to AD Application (aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb)
 
 ## PARAMETERS
 

--- a/azps-12.5.0/Az.Resources/Get-AzADAppPermission.md
+++ b/azps-12.5.0/Az.Resources/Get-AzADAppPermission.md
@@ -33,7 +33,7 @@ Lists API permissions the application has requested.
 
 ### Example 1: Get API permission
 ```powershell
-Get-AzADAppPermission -ObjectId 18797549-86a9-4906-b2a9-54f08cd3c427
+Get-AzADAppPermission -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
 ```output
@@ -43,7 +43,7 @@ ApiId                                Id                                   Type
 00000003-0000-0000-c000-000000000000 5b567255-7703-4780-807c-7be8301ae99b Scope
 ```
 
-Fetches all API permissions of Azure AD object 18797549-86a9-4906-b2a9-54f08cd3c427
+Fetches all API permissions of Azure AD object aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 
 ## PARAMETERS
 

--- a/azps-12.5.0/Az.Resources/Get-AzDenyAssignment.md
+++ b/azps-12.5.0/Az.Resources/Get-AzDenyAssignment.md
@@ -179,12 +179,12 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  All Principals
                           ObjectType:   SystemDefined
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {
                           DisplayName:  testuser
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 IsSystemProtected       : True
 
@@ -200,11 +200,11 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  testuser
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           ,
                           DisplayName:  PowershellTestingApp
                           ObjectType:   ServicePrincipal
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True
@@ -231,7 +231,7 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  john.doe
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True
@@ -248,11 +248,11 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  john.doe
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           ,
                           DisplayName:  PowershellTestingApp
                           ObjectType:   ServicePrincipal
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True
@@ -279,7 +279,7 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  TestApp
                           ObjectType:   ServicePrincipal
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True
@@ -296,11 +296,11 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  testuser
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           ,
                           DisplayName:  TestApp
                           ObjectType:   ServicePrincipal
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True
@@ -327,7 +327,7 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  testuser
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True
@@ -344,11 +344,11 @@ DoNotApplyToChildScopes : False
 Principals              : {
                           DisplayName:  testuser
                           ObjectType:   User
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           ,
                           DisplayName:  TestApp
                           ObjectType:   ServicePrincipal
-                          ObjectId:     00001111-aaaa-2222-bbbb-3333cccc4444
+                          ObjectId:     aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
                           }
 ExcludePrincipals       : {}
 IsSystemProtected       : True

--- a/azps-12.5.0/Az.Resources/Get-AzManagementGroup.md
+++ b/azps-12.5.0/Az.Resources/Get-AzManagementGroup.md
@@ -40,13 +40,13 @@ Get-AzManagementGroup
 Id          : /providers/Microsoft.Management/managementGroups/TestGroup
 Type        : /providers/Microsoft.Management/managementGroups
 Name        : TestGroup
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName : TestGroupDisplayName
 
 Id          : /providers/Microsoft.Management/managementGroups/TestGroupChild
 Type        : /providers/Microsoft.Management/managementGroups
 Name        : TestGroupChild
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName : TestGroupChildDisplayName
 ```
 
@@ -61,7 +61,7 @@ Get-AzManagementGroup -GroupName TestGroup
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -83,7 +83,7 @@ $response
 Id                : /providers/Microsoft.Management/managementGroups/TestGroupParent
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroupParent
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupParent
 UpdatedTime       : 2/1/2018 11:15:46 AM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -114,7 +114,7 @@ $response
 Id                : /providers/Microsoft.Management/managementGroups/TestGroupParent
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroupParent
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupParent
 UpdatedTime       : 2/1/2018 11:15:46 AM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9

--- a/azps-12.5.0/Az.Resources/Get-AzManagementGroupEntity.md
+++ b/azps-12.5.0/Az.Resources/Get-AzManagementGroupEntity.md
@@ -33,13 +33,13 @@ Get-AzManagementGroupEntity
 Id          : /providers/Microsoft.Management/managementGroups/TestGroup
 Type        : Microsoft.Management/managementGroups
 Name        : TestGroup
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName : TestGroupDisplayName
 
 Id          : /providers/Microsoft.Management/managementGroups/TestGroupChild
 Type        : /providers/Microsoft.Management/managementGroups
 Name        : TestGroupChild
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName : TestGroupChildDisplayName
 ```
 

--- a/azps-12.5.0/Az.Resources/Get-AzManagementGroupHierarchySetting.md
+++ b/azps-12.5.0/Az.Resources/Get-AzManagementGroupHierarchySetting.md
@@ -40,7 +40,7 @@ Get-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869baa0
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : true
 DefaultManagementGroup : TestGroup
 ```

--- a/azps-12.5.0/Az.Resources/Get-AzManagementGroupSubscription.md
+++ b/azps-12.5.0/Az.Resources/Get-AzManagementGroupSubscription.md
@@ -27,14 +27,14 @@ The **Get-AzManagementGroupSubscription** cmdlet gets the subscription info unde
 
 ### Example 1: Get Subscription Details under a Management Group
 ```powershell
-Get-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId 5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
+Get-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
-Name              : 5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
+Name              : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Type              : Microsoft.Management/managementGroups/subscriptions
-Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : Visual Studio Enterprise Subscription
 ParentId          : /providers/Microsoft.Management/managementGroups/TestGroup
 State             : Active
@@ -46,10 +46,10 @@ Get-AzManagementGroupSubscription -GroupName "TestGroup"
 ```
 
 ```output
-Name              : 5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
+Name              : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Type              : Microsoft.Management/managementGroups/subscriptions
-Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : Visual Studio Enterprise Subscription
 ParentId          : /providers/Microsoft.Management/managementGroups/TestGroup
 State             : Active
@@ -57,7 +57,7 @@ State             : Active
 Name              : 2120692d-35c3-44c8-81f5-631fa7351726
 Type              : Microsoft.Management/managementGroups/subscriptions
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/2120692d-35c3-44c8-81f5-631fa7351726
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : Test Subscription
 ParentId          : /providers/Microsoft.Management/managementGroups/TestGroup
 State             : Active

--- a/azps-12.5.0/Az.Resources/Get-AzPolicyDefinition.md
+++ b/azps-12.5.0/Az.Resources/Get-AzPolicyDefinition.md
@@ -96,10 +96,10 @@ This command gets the policy definition named VMPolicyDefinition from the manage
 
 ### Example 4: Get all built-in policy definitions from subscription
 ```powershell
-Get-AzPolicyDefinition -SubscriptionId '3bf44b72-c631-427a-b8c8-53e2595398ca' -Builtin
+Get-AzPolicyDefinition -SubscriptionId 'aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e' -Builtin
 ```
 
-This command gets all built-in policy definitions from the subscription with ID 3bf44b72-c631-427a-b8c8-53e2595398ca.
+This command gets all built-in policy definitions from the subscription with ID aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e.
 
 ### Example 5: Get policy definitions from a given category
 ```powershell

--- a/azps-12.5.0/Az.Resources/Get-AzPolicySetDefinition.md
+++ b/azps-12.5.0/Az.Resources/Get-AzPolicySetDefinition.md
@@ -83,10 +83,10 @@ This command gets the policy set definition named VMPolicySetDefinition from the
 
 ### Example 3: Get policy set definition from subscription by name
 ```powershell
-Get-AzPolicySetDefinition -Name 'VMPolicySetDefinition' -subscriptionId '3bf44b72-c631-427a-b8c8-53e2595398ca'
+Get-AzPolicySetDefinition -Name 'VMPolicySetDefinition' -subscriptionId 'aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e'
 ```
 
-This command gets the policy definition named VMPolicySetDefinition from the subscription with ID 3bf44b72-c631-427a-b8c8-53e2595398ca.
+This command gets the policy definition named VMPolicySetDefinition from the subscription with ID aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e.
 
 ### Example 4: Get all custom policy set definitions from management group
 ```powershell

--- a/azps-12.5.0/Az.Resources/Get-AzPrivateLinkAssociation.md
+++ b/azps-12.5.0/Az.Resources/Get-AzPrivateLinkAssociation.md
@@ -26,45 +26,45 @@ The Get-AzPrivateLinkAssociation cmdlet gets all of resource management private 
 
 ### Example 1
 ```powershell
-Get-AzPrivateLinkAssociation -ManagementGroupId fc096d27-0434-4460-a3ea-110df0422a2d | Format-List
+Get-AzPrivateLinkAssociation -ManagementGroupId aaaabbbb-0000-cccc-1111-dddd2222eeee | Format-List
 ```
 
 ```output
-Id         : /providers/Microsoft.Management/managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d/providers/Microsoft.
+Id         : /providers/Microsoft.Management/managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee/providers/Microsoft.
              Authorization/privateLinkAssociations/7afcb623-ff23-591c-8cdd-57f5357711f4
 Type       : Microsoft.Authorization/privateLinkAssociations
 Name       : 7afcb623-ff23-591c-8cdd-57f5357711f4
 Properties : {"privateLink":"/subscriptions/aeb49941-36c3-4e7c-9ffd-16ba89d33ec4/resourceGroups/nrp-validate/providers/
              Microsoft.Authorization/resourceManagementPrivateLinks/DeepDiveRMPL","publicNetworkAccess":"Enabled","tena
-             ntID":"fc096d27-0434-4460-a3ea-110df0422a2d","scope":"/providers/Microsoft.Management/managementGroups/24f
+             ntID":"aaaabbbb-0000-cccc-1111-dddd2222eeee","scope":"/providers/Microsoft.Management/managementGroups/24f
              15700-370c-45bc-86a7-aee1b0c4eb8a"}
 
-Id         : /providers/Microsoft.Management/managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d/providers/Microsoft.
+Id         : /providers/Microsoft.Management/managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee/providers/Microsoft.
              Authorization/privateLinkAssociations/1d7942d1-288b-48de-8d0f-2d2aa8e03ad4
 Type       : Microsoft.Authorization/privateLinkAssociations
 Name       : 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4
 Properties : {"privateLink":"/subscriptions/aeb49941-36c3-4e7c-9ffd-16ba89d33ec4/resourceGroups/nrp-validate/providers/
              Microsoft.Authorization/resourceManagementPrivateLinks/DeepDiveRMPL","publicNetworkAc
-             cess":"Enabled","tenantID":"fc096d27-0434-4460-a3ea-110df0422a2d","scope":"/providers/Microsoft.Management
-             /managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d"}
+             cess":"Enabled","tenantID":"aaaabbbb-0000-cccc-1111-dddd2222eeee","scope":"/providers/Microsoft.Management
+             /managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee"}
 ```
 
 Get all the private link associations at the managment group scope.
 
 ### Example 2
 ```powershell
-Get-AzPrivateLinkAssociation -ManagementGroupId fc096d27-0434-4460-a3ea-110df0422a2d -Name 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4 | Format-List
+Get-AzPrivateLinkAssociation -ManagementGroupId aaaabbbb-0000-cccc-1111-dddd2222eeee -Name 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4 | Format-List
 ```
 
 ```output
-Id         : /providers/Microsoft.Management/managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d/providers/Microsoft.
+Id         : /providers/Microsoft.Management/managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee/providers/Microsoft.
              Authorization/privateLinkAssociations/1d7942d1-288b-48de-8d0f-2d2aa8e03ad4
 Type       : Microsoft.Authorization/privateLinkAssociations
 Name       : 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4
 Properties : {"privateLink":"/subscriptions/aeb49941-36c3-4e7c-9ffd-16ba89d33ec4/resourceGroups/nrp-validate/providers/
              Microsoft.Authorization/resourceManagementPrivateLinks/DeepDiveRMPL","publicNetworkAc
-             cess":"Enabled","tenantID":"fc096d27-0434-4460-a3ea-110df0422a2d","scope":"/providers/Microsoft.Management
-             /managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d"}
+             cess":"Enabled","tenantID":"aaaabbbb-0000-cccc-1111-dddd2222eeee","scope":"/providers/Microsoft.Management
+             /managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee"}
 ```
 
 Get the specific private link associations at the managment group scope.

--- a/azps-12.5.0/Az.Resources/New-AzADAppFederatedCredential.md
+++ b/azps-12.5.0/Az.Resources/New-AzADAppFederatedCredential.md
@@ -27,7 +27,7 @@ Create federatedIdentityCredential for applications.
 
 ### Example 1: Create federated identity credential for application
 ```powershell
-New-AzADAppFederatedCredential -ApplicationObjectId $appObjectId -Audience api://AzureADTokenExchange -Issuer https://login.microsoftonline.com/3d1e2be9-a10a-4a0c-8380-7ce190f98ed9/v2.0 -name 'test-cred' -Subject 'subject'
+New-AzADAppFederatedCredential -ApplicationObjectId $appObjectId -Audience api://AzureADTokenExchange -Issuer https://login.microsoftonline.com/aaaabbbb-0000-cccc-1111-dddd2222eeee/v2.0 -name 'test-cred' -Subject 'subject'
 ```
 
 Create federated identity credential for application

--- a/azps-12.5.0/Az.Resources/New-AzADServicePrincipalAppRoleAssignment.md
+++ b/azps-12.5.0/Az.Resources/New-AzADServicePrincipalAppRoleAssignment.md
@@ -49,26 +49,26 @@ Create new navigation property to appRoleAssignments for servicePrincipals
 
 ### Example 1: ObjectIdWithResourceIdParameterSet
 ```powershell
-New-AzADServicePrincipalAppRoleAssignment -ServicePrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -ResourceId 351fa797-c81a-4998-9720-4c2ecb6c7abc -AppRoleId 649ae968-bdf9-4f22-bb2c-2aa1b4af0a83
+New-AzADServicePrincipalAppRoleAssignment -ServicePrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -ResourceId a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1 -AppRoleId b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2
 ```
 
 ```output
 Id                                          AppRoleId                            PrincipalDisplayName PrincipalId                          CreatedDateTime
 --                                          ---------                            -------------------- -----------                          ---------------
-Zbm-cUeDXUmlicIc3eenIkgIm8kv9kJPj4MFhepACNE 649ae968-bdf9-4f22-bb2c-2aa1b4af0a83 funapp1214           00001111-aaaa-2222-bbbb-3333cccc4444 12/14/2023 7:04:28 AM
+Zbm-cUeDXUmlicIc3eenIkgIm8kv9kJPj4MFhepACNE b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2 funapp1214           00001111-aaaa-2222-bbbb-3333cccc4444 12/14/2023 7:04:28 AM
 ```
 
 Create an appRoleAssignment using ServicePrincipalId and ResourceId.
 
 ### Example 2: SPNWithResourceDisplayNameParameterSet
 ```powershell
-New-AzADServicePrincipalAppRoleAssignment -ServicePrincipalDisplayName funapp1214 -ResourceDisplayName nori-sp -AppRoleId 649ae968-bdf9-4f22-bb2c-2aa1b4af0a83
+New-AzADServicePrincipalAppRoleAssignment -ServicePrincipalDisplayName funapp1214 -ResourceDisplayName nori-sp -AppRoleId b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2
 ```
 
 ```output
 Id                                          AppRoleId                            PrincipalDisplayName PrincipalId                          CreatedDateTime
 --                                          ---------                            -------------------- -----------                          ---------------
-Zbm-cUeDXUmlicIc3eenIlqgWRlWp2hFrXIJiqP2j78 649ae968-bdf9-4f22-bb2c-2aa1b4af0a83 funapp1214           00001111-aaaa-2222-bbbb-3333cccc4444 12/14/2023 7:07:16 AM
+Zbm-cUeDXUmlicIc3eenIlqgWRlWp2hFrXIJiqP2j78 b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2 funapp1214           00001111-aaaa-2222-bbbb-3333cccc4444 12/14/2023 7:07:16 AM
 ```
 
 Create an appRoleAssignment for service principal using ServicePrincipal DisplayName and Resource DisplayName.

--- a/azps-12.5.0/Az.Resources/New-AzManagementGroup.md
+++ b/azps-12.5.0/Az.Resources/New-AzManagementGroup.md
@@ -42,7 +42,7 @@ New-AzManagementGroup -GroupName "TestGroup"
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroup
 UpdatedTime       : 2/1/2018 11:06:27 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444
@@ -62,7 +62,7 @@ New-AzManagementGroup -GroupName "TestGroup" -DisplayName "TestGroupDisplayName"
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroup
 UpdatedTime       : 2/1/2018 11:06:27 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444
@@ -82,7 +82,7 @@ New-AzManagementGroup -GroupName "TestGroup" -DisplayName "TestGroupDisplayName"
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444
@@ -101,7 +101,7 @@ New-AzManagementGroup -GroupName "TestGroup" -ParentObject $parentObject
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444

--- a/azps-12.5.0/Az.Resources/New-AzManagementGroupHierarchySetting.md
+++ b/azps-12.5.0/Az.Resources/New-AzManagementGroupHierarchySetting.md
@@ -42,7 +42,7 @@ New-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869baa0
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : true
 DefaultManagementGroup :
 ```
@@ -56,7 +56,7 @@ New-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869baa0
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : false
 DefaultManagementGroup : TestGroup
 ```
@@ -70,7 +70,7 @@ New-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869baa0
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : true
 DefaultManagementGroup : TestGroup
 ```

--- a/azps-12.5.0/Az.Resources/New-AzManagementGroupSubscription.md
+++ b/azps-12.5.0/Az.Resources/New-AzManagementGroupSubscription.md
@@ -27,14 +27,14 @@ The **New-AzManagementGroupSubscription** cmdlet adds a Subscription to a Manage
 
 ### Example 1: Add Subscription to a Management Group
 ```powershell
-New-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId 5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
+New-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
-Name              : 5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
+Name              : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Type              : Microsoft.Management/managementGroups/subscriptions
-Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/5602fbd9-fb0d-4fbb-98b3-10c8ea20b6de
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+Id                : /providers/Microsoft.Management/managementGroups/TestGroup/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : Visual Studio Enterprise Subscription
 ParentId          : /providers/Microsoft.Management/managementGroups/TestGroup
 State             : Active

--- a/azps-12.5.0/Az.Resources/New-AzPrivateLinkAssociation.md
+++ b/azps-12.5.0/Az.Resources/New-AzPrivateLinkAssociation.md
@@ -27,18 +27,18 @@ The New-AzPrivateLinkAssociation cmdlet creates the private link assocaition at 
 
 ### Example 1
 ```powershell
-New-AzPrivateLinkAssociation -ManagementGroupId fc096d27-0434-4460-a3ea-110df0422a2d -Name 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4 | Format-List
+New-AzPrivateLinkAssociation -ManagementGroupId aaaabbbb-0000-cccc-1111-dddd2222eeee -Name 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4 | Format-List
 ```
 
 ```output
-Id         : /providers/Microsoft.Management/managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d/providers/Microsoft.
+Id         : /providers/Microsoft.Management/managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee/providers/Microsoft.
              Authorization/privateLinkAssociations/1d7942d1-288b-48de-8d0f-2d2aa8e03ad4
 Type       : Microsoft.Authorization/privateLinkAssociations
 Name       : 1d7942d1-288b-48de-8d0f-2d2aa8e03ad4
 Properties : {"privateLink":"/subscriptions/aeb49941-36c3-4e7c-9ffd-16ba89d33ec4/resourceGroups/nrp-validate/providers/
              Microsoft.Authorization/resourceManagementPrivateLinks/DeepDiveRMPL","publicNetworkAc
-             cess":"Enabled","tenantID":"fc096d27-0434-4460-a3ea-110df0422a2d","scope":"/providers/Microsoft.Management
-             /managementGroups/fc096d27-0434-4460-a3ea-110df0422a2d"}
+             cess":"Enabled","tenantID":"aaaabbbb-0000-cccc-1111-dddd2222eeee","scope":"/providers/Microsoft.Management
+             /managementGroups/aaaabbbb-0000-cccc-1111-dddd2222eeee"}
 ```
 
 Creates the specific private link associations at the managment group scope.

--- a/azps-12.5.0/Az.Resources/New-AzRoleAssignment.md
+++ b/azps-12.5.0/Az.Resources/New-AzRoleAssignment.md
@@ -153,7 +153,7 @@ Get-AzADGroup -SearchString "Christine Koch Team"
           -----------                    ----                           --------
           Christine Koch Team                                           00001111-aaaa-2222-bbbb-3333cccc4444
 
-New-AzRoleAssignment -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -RoleDefinitionName Contributor  -ResourceGroupName rg1
+New-AzRoleAssignment -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -RoleDefinitionName Contributor  -ResourceGroupName rg1
 ```
 
 Grant access to a security group
@@ -167,7 +167,7 @@ Grant access to a user at a resource (website)
 
 ### Example 4
 ```powershell
-New-AzRoleAssignment -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -RoleDefinitionName "Virtual Machine Contributor" -ResourceName Devices-Engineering-ProjectRND -ResourceType Microsoft.Network/virtualNetworks/subnets -ParentResource virtualNetworks/VNET-EASTUS-01 -ResourceGroupName Network
+New-AzRoleAssignment -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -RoleDefinitionName "Virtual Machine Contributor" -ResourceName Devices-Engineering-ProjectRND -ResourceType Microsoft.Network/virtualNetworks/subnets -ParentResource virtualNetworks/VNET-EASTUS-01 -ResourceGroupName Network
 ```
 
 Grant access to a group at a nested resource (subnet)

--- a/azps-12.5.0/Az.Resources/New-AzRoleAssignmentScheduleRequest.md
+++ b/azps-12.5.0/Az.Resources/New-AzRoleAssignmentScheduleRequest.md
@@ -33,14 +33,14 @@ Creates a role assignment schedule request.
 ```powershell
 $guid = "12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca"
 $startTime = Get-Date -Format o 
-$scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -RequestType AdminAssign -RoleDefinitionId subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
+$scope = "/subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/"
+New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -RequestType AdminAssign -RoleDefinitionId subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
 ```
 
 ```output
 Name                                 Type                                                    Scope                                               RoleDefinitionId
 ----                                 ----                                                    -----                                               ----------------                                                                 
-12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authori…
+12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222 /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authori…
 ```
 
 Creates a request to provision an active assignment of `roleDefinition` on the `scope` for the specified `principal`
@@ -49,14 +49,14 @@ Creates a request to provision an active assignment of `roleDefinition` on the `
 ```powershell
 $guid = "13f8978c-5d8d-4fbf-b4b6-2f43eeb43eca"
 $startTime = Get-Date -Format o 
-$scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -RequestType AdminRemove -RoleDefinitionId subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
+$scope = "/subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/"
+New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -RequestType AdminRemove -RoleDefinitionId subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
 ```
 
 ```output
 Name                                 Type                                                    Scope                                               RoleDefinitionId
 ----                                 ----                                                    -----                                               ----------------                                                                 
-13f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authori…
+13f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222 /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authori…
 ```
 
 Creates a request to remove an active assignment of `roleDefinition` on the `scope` for the specified `principal`
@@ -65,14 +65,14 @@ Creates a request to remove an active assignment of `roleDefinition` on the `sco
 ```powershell
 $guid = "12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca"
 $startTime = Get-Date -Format o 
-$scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -RequestType SelfActivate -RoleDefinitionId subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
+$scope = "/subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/"
+New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -RequestType SelfActivate -RoleDefinitionId subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
 ```
 
 ```output
 Name                                 Type                                                    Scope                                               RoleDefinitionId
 ----                                 ----                                                    -----                                               ----------------                                                                 
-12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authori…
+12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222 /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authori…
 ```
 
 Creates a request to activate an eligible assignment of `roleDefinition` on the `scope` for the specified `principal`
@@ -81,14 +81,14 @@ Creates a request to activate an eligible assignment of `roleDefinition` on the 
 ```powershell
 $guid = "12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca"
 $startTime = Get-Date -Format o 
-$scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -RequestType SelfDeactivate -RoleDefinitionId subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
+$scope = "/subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/"
+New-AzRoleAssignmentScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -RequestType SelfDeactivate -RoleDefinitionId subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
 ```
 
 ```output
 Name                                 Type                                                    Scope                                               RoleDefinitionId
 ----                                 ----                                                    -----                                               ----------------                                                                 
-12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authori…
+12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleAssignmentScheduleRequests /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222 /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authori…
 ```
 
 Creates a request to deactivate an eligible assignment of `roleDefinition` on the `scope` for the specified `principal`

--- a/azps-12.5.0/Az.Resources/New-AzRoleEligibilityScheduleRequest.md
+++ b/azps-12.5.0/Az.Resources/New-AzRoleEligibilityScheduleRequest.md
@@ -33,14 +33,14 @@ Creates a role eligibility schedule request.
 ```powershell
 $guid = "12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca"
 $startTime = Get-Date -Format o 
-$scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-New-AzRoleEligibilityScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -RequestType AdminAssign -RoleDefinitionId subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
+$scope = "/subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/"
+New-AzRoleEligibilityScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -RequestType AdminAssign -RoleDefinitionId subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
 ```
 
 ```output
 Name                                 Type                                                    Scope                                               RoleDefinitionId
 ----                                 ----                                                    -----                                               ----------------                                                                 
-12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleEligibilityScheduleRequests /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authori…
+12f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleEligibilityScheduleRequests /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222 /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authori…
 ```
 
 Creates a request to provision an eligible assignment of `roleDefinition` on the `scope` for the specified `principal`
@@ -49,14 +49,14 @@ Creates a request to provision an eligible assignment of `roleDefinition` on the
 ```powershell
 $guid = "13f8978c-5d8d-4fbf-b4b6-2f43eeb43eca"
 $startTime = Get-Date -Format o 
-$scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-New-AzRoleEligibilityScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId 00001111-aaaa-2222-bbbb-3333cccc4444 -RequestType AdminRemove -RoleDefinitionId subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
+$scope = "/subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/"
+New-AzRoleEligibilityScheduleRequest -Name $guid -Scope $scope -ExpirationDuration PT1H -ExpirationType AfterDuration -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -RequestType AdminRemove -RoleDefinitionId subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7 -ScheduleInfoStartDateTime $startTime
 ```
 
 ```output
 Name                                 Type                                                    Scope                                               RoleDefinitionId
 ----                                 ----                                                    -----                                               ----------------                                                                 
-13f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleEligibilityScheduleRequests /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d /subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/providers/Microsoft.Authori…
+13f8978c-5d8d-4fbf-b4b6-2f43eeb43eca Microsoft.Authorization/roleEligibilityScheduleRequests /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222 /subscriptions/aaaaaaaa-bbbb-cccc-1111-222222222222/providers/Microsoft.Authori…
 ```
 
 Creates a request to remove an eligible assignment of `roleDefinition` on the `scope` for the specified `principal`

--- a/azps-12.5.0/Az.Resources/Remove-AzADAppPermission.md
+++ b/azps-12.5.0/Az.Resources/Remove-AzADAppPermission.md
@@ -33,10 +33,10 @@ Removes an API permission.
 
 ### Example 1: Remove API Permission
 ```powershell
-Remove-AzADAppPermission -ObjectId 9cc74d5e-1162-4b90-8696-65f3d6a3f7d0 -PermissionId 5f8c59db-677d-491f-a6b8-5f174b11ec1d
+Remove-AzADAppPermission -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PermissionId 5f8c59db-677d-491f-a6b8-5f174b11ec1d
 ```
 
-Remove delegated permission "Group.Read.All" of Microsoft Graph API from AD Application (9cc74d5e-1162-4b90-8696-65f3d6a3f7d0)
+Remove delegated permission "Group.Read.All" of Microsoft Graph API from AD Application (aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb)
 
 ## PARAMETERS
 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
