### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 44)

### DIFF
--- a/azps-12.5.0/Az.SecurityInsights/Get-AzSentinelEntityActivity.md
+++ b/azps-12.5.0/Az.SecurityInsights/Get-AzSentinelEntityActivity.md
@@ -48,7 +48,7 @@ This command gets insights and activities for an Entity.
 
 ### Example 2: Get Insights and Activities for an Entity by Id
 ```powershell
-$Entity = Get-AzSentinelEntity -ResourceGroupName "myResourceGroupName" -workspaceName "myWorkspaceName" -EntityId "00001111-aaaa-2222-bbbb-3333cccc4444"
+$Entity = Get-AzSentinelEntity -ResourceGroupName "myResourceGroupName" -workspaceName "myWorkspaceName" -EntityId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
  $Entity | Get-AzSentinelEntityActivity
 ```
 

--- a/azps-12.5.0/Az.SecurityInsights/Get-AzSentinelEntityInsight.md
+++ b/azps-12.5.0/Az.SecurityInsights/Get-AzSentinelEntityInsight.md
@@ -47,7 +47,7 @@ This command gets insights for an Entity for a given time range.
 ```powershell
 $startTime = (Get-Date).AddDays(-7).ToUniversalTime() | Get-Date -Format "yyyy-MM-ddThh:00:00.000Z"
  $endTime = (Get-Date).ToUniversalTime() | Get-Date -Format "yyyy-MM-ddThh:00:00.000Z"
- $Entity = Get-AzSentinelEntity -ResourceGroupName "myResourceGroupName" -workspaceName "myWorkspaceName" -EntityId "00001111-aaaa-2222-bbbb-3333cccc4444"
+ $Entity = Get-AzSentinelEntity -ResourceGroupName "myResourceGroupName" -workspaceName "myWorkspaceName" -EntityId "00aa00aa-bb11-cc22-dd33-44ee44ee44ee"
  $Entity | Get-AzSentinelEntityInsight -EndTime $endTime -StartTime $startTime
 ```
 

--- a/azps-12.5.0/Az.SecurityInsights/New-AzSentinelIncidentTeam.md
+++ b/azps-12.5.0/Az.SecurityInsights/New-AzSentinelIncidentTeam.md
@@ -44,7 +44,7 @@ $incident = Get-AzSentinelIncident -ResourceGroupName "myResourceGroup" -Workspa
 Description         :
 Name                : Incident : NewIncident3
 PrimaryChannelUrl   : https://teams.microsoft.com/l/team/19:vYoGjeGlZmTEDmu0gTbrk9T_eDS4pKIkEU7UuM1IyZk1%40thread.tacv2/conversations?groupId=3c637cc5-caf1-46c7-93ac-069c6
-                      4b05395&tenantId=00001111-aaaa-2222-bbbb-3333cccc4444
+                      4b05395&tenantId=aaaabbbb-0000-cccc-1111-dddd2222eeee
 TeamCreationTimeUtc : 2/4/2022 3:02:03 PM
 TeamId              : 3c637cc5-caf1-46c7-93ac-069c64b05395
 ```


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
