### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 46)

### DIFF
--- a/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterApplication.md
+++ b/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterApplication.md
@@ -58,7 +58,7 @@ This example gets a list of the managed applications under the cluster "testClus
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp"
 Get-AzServiceFabricManagedClusterApplication -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterApplicationType.md
+++ b/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterApplicationType.md
@@ -58,7 +58,7 @@ This example will get a list of the managed application types defined under the 
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType"
 Get-AzServiceFabricManagedClusterApplicationType -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterApplicationTypeVersion.md
+++ b/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterApplicationTypeVersion.md
@@ -60,7 +60,7 @@ This example gets a list of the managed application type versions defined under 
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType/versions/v1"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType/versions/v1"
 Get-AzServiceFabricManagedClusterApplicationTypeVersion -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterService.md
+++ b/azps-12.5.0/Az.ServiceFabric/Get-AzServiceFabricManagedClusterService.md
@@ -60,7 +60,7 @@ This example gets a list of the managed services under the application "testApp"
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
 Get-AzServiceFabricManagedClusterService -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterApplication.md
+++ b/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterApplication.md
@@ -61,7 +61,7 @@ This example removes the managed application "testApp" under the resource group 
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
 Remove-AzServiceFabricManagedClusterApplication -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterApplicationType.md
+++ b/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterApplicationType.md
@@ -61,7 +61,7 @@ This example will remove the managed application type "testAppType" and all the 
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType"
 Remove-AzServiceFabricManagedClusterApplicationType -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterApplicationTypeVersion.md
+++ b/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterApplicationTypeVersion.md
@@ -64,7 +64,7 @@ This example will remove the managed version "v1" under the type "testAppType". 
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType/versions/v1"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType/versions/v1"
 Remove-AzServiceFabricManagedClusterApplicationTypeVersion -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterService.md
+++ b/azps-12.5.0/Az.ServiceFabric/Remove-AzServiceFabricManagedClusterService.md
@@ -63,7 +63,7 @@ This example will remove the managed service testService1".
 
 ### Example 3
 ```powershell
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
 Remove-AzServiceFabricManagedClusterService -ResourceId $resourceId
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Set-AzServiceFabricManagedClusterApplicationType.md
+++ b/azps-12.5.0/Az.ServiceFabric/Set-AzServiceFabricManagedClusterApplicationType.md
@@ -64,7 +64,7 @@ This example will update the managed application type "testAppType" tags.
 ### Example 3
 ```powershell
 $newTags = @{new="tags"}
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType"
 Set-AzServiceFabricManagedClusterApplicationType -ResourceId $resourceId -Tag $newTags
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Set-AzServiceFabricManagedClusterApplicationTypeVersion.md
+++ b/azps-12.5.0/Az.ServiceFabric/Set-AzServiceFabricManagedClusterApplicationTypeVersion.md
@@ -70,7 +70,7 @@ This example will update the managed application type version "v1" tags and pack
 ```powershell
 $newTags = @{new="tags"}
 $packageUrl = "https://sftestapp.blob.core.windows.net/sftestapp/testAppType_v1.sfpkg"
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType/versions/v1"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applicationTypes/testAppType/versions/v1"
 Set-AzServiceFabricManagedClusterApplicationTypeVersion -ResourceId $resourceId -Tag $newTags -PackageUrl $packageUrl -Verbose
 ```
 

--- a/azps-12.5.0/Az.ServiceFabric/Set-AzServiceFabricManagedClusterService.md
+++ b/azps-12.5.0/Az.ServiceFabric/Set-AzServiceFabricManagedClusterService.md
@@ -112,7 +112,7 @@ This example will remove the managed service testService1".
 ```powershell
 $standByReplicaKeepDuration = "00:11:00"
 $servicePlacementTimeLimit = "00:11:00"
-$resourceId = "/subscriptions/13ad2c84-84fa-4798-ad71-e70c07af873f/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
+$resourceId = "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourcegroups/testRG/providers/Microsoft.ServiceFabric/managedClusters/testCluster/applications/testApp/services/testService"
 Set-AzServiceFabricManagedClusterService -ResourceId $resourceId -StandByReplicaKeepDuration $standByReplicaKeepDuration -ServicePlacementTimeLimit $servicePlacementTimeLimit -Verbose
 ```
 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
