### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 52)

### DIFF
--- a/azps-12.5.0/Az.StandbyPool/Get-AzStandbyContainerGroupPool.md
+++ b/azps-12.5.0/Az.StandbyPool/Get-AzStandbyContainerGroupPool.md
@@ -46,20 +46,20 @@ Get a StandbyContainerGroupPoolResource
 ### Example 1: Get a standby container group pool
 ```powershell
 Get-AzStandbyContainerGroupPool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -Name testPool `
 -ResourceGroupName test-standbypool
 ```
 
 ```output
-ContainerGroupProfileId           : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG
+ContainerGroupProfileId           : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG
 ContainerGroupProfileRevision     : 1
 ContainerGroupPropertySubnetId    : {{
-                                      "id": "/subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"
+                                      "id": "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"
                                     }}
 ElasticityProfileMaxReadyCapacity : 1
 ElasticityProfileRefillPolicy     : always
-Id                                : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyContainerGroupPools/testPool
+Id                                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyContainerGroupPools/testPool
 Location                          : eastus
 Name                              : testPool
 ProvisioningState                 : Succeeded

--- a/azps-12.5.0/Az.StandbyPool/Get-AzStandbyContainerGroupPoolStatus.md
+++ b/azps-12.5.0/Az.StandbyPool/Get-AzStandbyContainerGroupPoolStatus.md
@@ -46,13 +46,13 @@ Get a StandbyContainerGroupPoolRuntimeViewResource
 ### Example 1: Get runtime view of a standby container group pool
 ```powershell
 Get-AzStandbyContainerGroupPoolStatus `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -Name testPool `
 -ResourceGroupName test-standbypool
 ```
 
 ```output
-Id                           : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Standb
+Id                           : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Standb
                                yPool/standbyContainerGroupPools/testPool/runtimeViews/latest
 InstanceCountSummary         : {{
                                  "instanceCountsByState": [

--- a/azps-12.5.0/Az.StandbyPool/Get-AzStandbyVMPool.md
+++ b/azps-12.5.0/Az.StandbyPool/Get-AzStandbyVMPool.md
@@ -46,16 +46,16 @@ Get a StandbyVirtualMachinePoolResource
 ### Example 1: get a standby virutal machine pool
 ```powershell
 Get-AzStandbyVMPool  `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -ResourceGroupName test-standbypool `
 -Name testPool
 ```
 
 ```output
-AttachedVirtualMachineScaleSetId  : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss
+AttachedVirtualMachineScaleSetId  : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss
 ElasticityProfileMaxReadyCapacity : 1
 ElasticityProfileMinReadyCapacity : 1
-Id                                : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/testPool
+Id                                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/testPool
 Location                          : eastus
 Name                              : testPool
 ProvisioningState                 : Succeeded

--- a/azps-12.5.0/Az.StandbyPool/Get-AzStandbyVMPoolStatus.md
+++ b/azps-12.5.0/Az.StandbyPool/Get-AzStandbyVMPoolStatus.md
@@ -46,13 +46,13 @@ Get a StandbyVirtualMachinePoolRuntimeViewResource
 ### Example 1: Get runtime view of a standby virtual machine pool
 ```powershell
 Get-AzStandbyVMPoolStatus `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -ResourceGroupName test-standbypool `
 -Name testPool
 ```
 
 ```output
-Id                           : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Standb
+Id                           : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Standb
                                yPool/standbyVirtualMachinePools/testPool/runtimeViews/latest
 InstanceCountSummary         : {{
                                  "instanceCountsByState": [

--- a/azps-12.5.0/Az.StandbyPool/New-AzStandbyContainerGroupPool.md
+++ b/azps-12.5.0/Az.StandbyPool/New-AzStandbyContainerGroupPool.md
@@ -45,25 +45,25 @@ Create a StandbyContainerGroupPoolResource
 ```powershell
 New-AzStandbyContainerGroupPool `
 -Name testPool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -ResourceGroupName test-standbypool `
 -Location eastus `
 -MaxReadyCapacity 1 `
 -RefillPolicy always `
--ContainerProfileId /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG `
+-ContainerProfileId /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG `
 -ProfileRevision 1 `
--SubnetId @{id="/subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"} `
+-SubnetId @{id="/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"} `
 ```
 
 ```output
-ContainerGroupProfileId           : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG
+ContainerGroupProfileId           : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG
 ContainerGroupProfileRevision     : 1
 ContainerGroupPropertySubnetId    : {{
-                                      "id": "/subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"
+                                      "id": "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"
                                     }}
 ElasticityProfileMaxReadyCapacity : 1
 ElasticityProfileRefillPolicy     : always
-Id                                : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyContainerGroupPools/testPool
+Id                                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyContainerGroupPools/testPool
 Location                          : eastus
 Name                              : testPool
 ProvisioningState                 : Succeeded

--- a/azps-12.5.0/Az.StandbyPool/New-AzStandbyVMPool.md
+++ b/azps-12.5.0/Az.StandbyPool/New-AzStandbyVMPool.md
@@ -46,19 +46,19 @@ Create a StandbyVirtualMachinePoolResource
 New-AzStandbyVMPool `
 -Name testPool `
 -ResourceGroupName test-standbypool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -Location eastus `
--VMSSId /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss `
+-VMSSId /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss `
 -MaxReadyCapacity 1 `
 -MinReadyCapacity 1 `
 -VMState Running
 ```
 
 ```output
-AttachedVirtualMachineScaleSetId  : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss
+AttachedVirtualMachineScaleSetId  : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss
 ElasticityProfileMaxReadyCapacity : 1
 ElasticityProfileMinReadyCapacity : 1
-Id                                : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/testPool
+Id                                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/testPool
 Location                          : eastus
 Name                              : testPool
 ProvisioningState                 : Succeeded

--- a/azps-12.5.0/Az.StandbyPool/Remove-AzStandbyContainerGroupPool.md
+++ b/azps-12.5.0/Az.StandbyPool/Remove-AzStandbyContainerGroupPool.md
@@ -35,7 +35,7 @@ Delete a StandbyContainerGroupPoolResource
 ### Example 1: Delete a standby container pool
 ```powershell
 Remove-AzStandbyContainerGroupPool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -Name testPool `
 -ResourceGroupName test-standbypool `
 -NoWait
@@ -44,7 +44,7 @@ Remove-AzStandbyContainerGroupPool `
 ```output
 Target
 ------
-https://management.azure.com/subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/providers/Microsoft.StandbyPool/locations/EASTUS/operationStatuses/551356ac-5eb6-45f7-b6b6-14df83ba036e*85A187C07F40830FA4E50DCF44CFFD9DE9CC801E92CB2EBC4992086870FC7F91?api-version=2023-12-01-preview&t=638483731215571130&c=MIIHADCCBeig…
+https://management.azure.com/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.StandbyPool/locations/EASTUS/operationStatuses/551356ac-5eb6-45f7-b6b6-14df83ba036e*85A187C07F40830FA4E50DCF44CFFD9DE9CC801E92CB2EBC4992086870FC7F91?api-version=2023-12-01-preview&t=638483731215571130&c=MIIHADCCBeig…
 ```
 
 Above command is deleting a standby container pool without waiting.

--- a/azps-12.5.0/Az.StandbyPool/Remove-AzStandbyVMPool.md
+++ b/azps-12.5.0/Az.StandbyPool/Remove-AzStandbyVMPool.md
@@ -35,7 +35,7 @@ Delete a StandbyVirtualMachinePoolResource
 ### Example 1: Delete a standby virtual machine pool
 ```powershell
 Remove-AzStandbyVMPool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -ResourceGroupName test-standbypool `
 -Name testPool `
 -NoWait
@@ -44,7 +44,7 @@ Remove-AzStandbyVMPool `
 ```output
 Target
 ------
-https://management.azure.com/subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/providers/Microsoft.StandbyPool/locations/EASTUS/operationStatuses/dd097fee-99c2-4423-be9a-08ed20bfbf28*9F4DB3114D3D8F7DED8497F0D441BD1016348E645BEF0AF23FFE9753EE918EA8?api-version=2023-12-01-preview&t=638483770276035131&c=MIIHADCCBeig…
+https://management.azure.com/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.StandbyPool/locations/EASTUS/operationStatuses/dd097fee-99c2-4423-be9a-08ed20bfbf28*9F4DB3114D3D8F7DED8497F0D441BD1016348E645BEF0AF23FFE9753EE918EA8?api-version=2023-12-01-preview&t=638483770276035131&c=MIIHADCCBeig…
 ```
 
 Above command is deleting a standby virtual machine pool without waiting.

--- a/azps-12.5.0/Az.StandbyPool/Update-AzStandbyContainerGroupPool.md
+++ b/azps-12.5.0/Az.StandbyPool/Update-AzStandbyContainerGroupPool.md
@@ -53,20 +53,20 @@ Update a StandbyContainerGroupPoolResource
 ```powershell
 Update-AzStandbyContainerGroupPool `
 -Name testPool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -ResourceGroupName test-standbypool `
 -MaxReadyCapacity 5
 ```
 
 ```output
-ContainerGroupProfileId           : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG
+ContainerGroupProfileId           : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/test-standbypool/providers/Microsoft.ContainerInstance/containerGroupProfiles/testCG
 ContainerGroupProfileRevision     : 1
 ContainerGroupPropertySubnetId    : {{
-                                      "id": "/subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"
+                                      "id": "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/default"
                                     }}
 ElasticityProfileMaxReadyCapacity : 5
 ElasticityProfileRefillPolicy     : always
-Id                                : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyContainerGroupPools/testPool
+Id                                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyContainerGroupPools/testPool
 Location                          : eastus
 Name                              : testPool
 ProvisioningState                 : Succeeded

--- a/azps-12.5.0/Az.StandbyPool/Update-AzStandbyVMPool.md
+++ b/azps-12.5.0/Az.StandbyPool/Update-AzStandbyVMPool.md
@@ -51,17 +51,17 @@ Update a StandbyVirtualMachinePoolResource
 ### Example 1: Update standby virtual machine pool's max ready capacity.
 ```powershell
 Update-AzStandbyVMPool `
--SubscriptionId f8da6e30-a9d8-48ab-b05c-3f7fe482e13b `
+-SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e `
 -ResourceGroupName test-standbypool `
 -Name testPool `
 -MaxReadyCapacity 2
 ```
 
 ```output
-AttachedVirtualMachineScaleSetId  : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss
+AttachedVirtualMachineScaleSetId  : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.Compute/virtualMachineScaleSets/test-vmss
 ElasticityProfileMaxReadyCapacity : 2
 ElasticityProfileMinReadyCapacity : 2
-Id                                : /subscriptions/f8da6e30-a9d8-48ab-b05c-3f7fe482e13b/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/testPool
+Id                                : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/test-standbypool/providers/Microsoft.StandbyPool/standbyVirtualMachinePools/testPool
 Location                          : eastus
 Name                              : testPool
 ProvisioningState                 : Succeeded


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
