### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 2)

### DIFF
--- a/azps-13.0.0/Az.ApiManagement/Get-AzApiManagementCache.md
+++ b/azps-13.0.0/Az.ApiManagement/Get-AzApiManagementCache.md
@@ -40,8 +40,8 @@ Get-AzApiManagementCache -Context $apimContext
 CacheId           : westus
 Description       : apim.redis.cache.windows.net
 ConnectionString  : {{5cc1848125a3f724dcf9a928}}
-ResourceId        : https://management.azure.com/subscriptions/a200340d-6b82-494d-9dbf-687ba6e33f9e/resourceGroups/Api-Default-West-US/providers/Microsoft.Cache/Redis/apim
-Id                : /subscriptions/a200340d-6b82-494d-9dbf-687ba6e33f9e/resourceGroups/Api-Default-West-US/providers/Microsoft.ApiManagement/service/contoso/caches/westus
+ResourceId        : https://management.azure.com/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Api-Default-West-US/providers/Microsoft.Cache/Redis/apim
+Id                : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Api-Default-West-US/providers/Microsoft.ApiManagement/service/contoso/caches/westus
 ResourceGroupName : Api-Default-West-US
 ServiceName       : contoso
 ```
@@ -58,8 +58,8 @@ Get-AzApiManagementCache -Context $apimContext -cacheId westus
 CacheId           : westus
 Description       : apim.redis.cache.windows.net
 ConnectionString  : {{5cc1848125a3f724dcf9a928}}
-ResourceId        : https://management.azure.com/subscriptions/a200340d-6b82-494d-9dbf-687ba6e33f9e/resourceGroups/Api-Default-West-US/providers/Microsoft.Cache/Redis/apim
-Id                : /subscriptions/a200340d-6b82-494d-9dbf-687ba6e33f9e/resourceGroups/Api-Default-WestUS/providers/Microsoft.ApiManagement/service/contoso/caches/westus
+ResourceId        : https://management.azure.com/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Api-Default-West-US/providers/Microsoft.Cache/Redis/apim
+Id                : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/Api-Default-WestUS/providers/Microsoft.ApiManagement/service/contoso/caches/westus
 ResourceGroupName : Api-Default-WestUS
 ServiceName       : contoso
 ```


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
