### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 7)

### DIFF
--- a/azps-13.0.0/Az.CloudService/Get-AzCloudServiceNetworkInterface.md
+++ b/azps-13.0.0/Az.CloudService/Get-AzCloudServiceNetworkInterface.md
@@ -48,14 +48,14 @@ Get the specified network interface in a cloud service.
 
 ### Example 1: Get network interfaces by a cloud service name
 ```powershell
-Get-AzCloudServiceNetworkInterface -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId 1133e0eb-b53c-1234-b478-2eac8f04afca
+Get-AzCloudServiceNetworkInterface -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 Gets all the network interfaces for a given cloud service name.
 
 ### Example 2: Get network interfaces by a cloud service object
 ```powershell
-$cs = Get-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId 1133e0eb-b53c-1234-b478-2eac8f04afca
+$cs = Get-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Get-AzCloudServiceNetworkInterface -InputObject $cs
 ```
 

--- a/azps-13.0.0/Az.CloudService/Get-AzCloudServicePublicIPAddress.md
+++ b/azps-13.0.0/Az.CloudService/Get-AzCloudServicePublicIPAddress.md
@@ -50,14 +50,14 @@ Get the specified public IP address in a cloud service.
 
 ### Example 1: Get instance level public IP addresses for a given cloud service name.
 ```powershell
-Get-AzCloudServicePublicIPAddress -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId 1133e0eb-b53c-1234-b478-2eac8f04afca
+Get-AzCloudServicePublicIPAddress -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 Gets the instance level public IP addresses for a given cloud service name.
 
 ### Example 2: Get instance level public IP addresses for a given cloud service object.
 ```powershell
-$cs = Get-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId 1133e0eb-b53c-1234-b478-2eac8f04afca
+$cs = Get-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Get-AzCloudServicePublicIPAddress -InputObject $cs
 ```
 

--- a/azps-13.0.0/Az.CloudService/Switch-AzCloudService.md
+++ b/azps-13.0.0/Az.CloudService/Switch-AzCloudService.md
@@ -35,7 +35,7 @@ Swaps VIPs between two cloud service (extended support) load balancers.
 
 ### Example 1: Switch cloud service using name
 ```powershell
-Switch-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId 1133e0eb-b53c-1234-b478-2eac8f04afca
+Switch-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 Above command invokes the vipswap operation on the Cloud service with name 'BService' and will perform the operation once the user confirms the action on the confirmation prompt.
@@ -43,7 +43,7 @@ Above command invokes the vipswap operation on the Cloud service with name 'BSer
 
 ### Example 2: Switch cloud service using cloud service object
 ```powershell
-$cs = Get-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId 1133e0eb-b53c-1234-b478-2eac8f04afca
+$cs = Get-AzCloudService -ResourceGroupName "BRGThree" -CloudServiceName BService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 Switch-AzCloudService -CloudService $cs
 ```
 


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
