### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 8)

### DIFF
--- a/azps-13.0.0/Az.Communication/Get-AzCommunicationService.md
+++ b/azps-13.0.0/Az.Communication/Get-AzCommunicationService.md
@@ -45,7 +45,7 @@ Get the CommunicationService and its properties.
 
 ### Example 1: List existing CommunicationServices for a Subscription
 ```powershell
-Get-AzCommunicationService -SubscriptionId 632ec9eb-fad7-4cbd-993a-e72973ba2acc
+Get-AzCommunicationService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output

--- a/azps-13.0.0/Az.Communication/Get-AzEmailService.md
+++ b/azps-13.0.0/Az.Communication/Get-AzEmailService.md
@@ -45,7 +45,7 @@ Get the EmailService and its properties.
 
 ### Example 1: List existing Email Services for a Subscription
 ```powershell
-Get-AzCommunicationService -SubscriptionId 73fc3592-3cef-4300-5e19-8d18b65ce0e8
+Get-AzCommunicationService -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
