### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 9)

### DIFF
--- a/azps-13.0.0/Az.ConfidentialLedger/New-AzConfidentialLedger.md
+++ b/azps-13.0.0/Az.ConfidentialLedger/New-AzConfidentialLedger.md
@@ -36,8 +36,8 @@ New-AzConfidentialLedger `
   -AadBasedSecurityPrincipal `
       @{
           LedgerRoleName="Administrator"; 
-          PrincipalId="00001111-aaaa-2222-bbbb-3333cccc4444"; 
-          TenantId="00001111-aaaa-2222-bbbb-3333cccc4444"
+          PrincipalId="ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0"; 
+          TenantId="aaaabbbb-0000-cccc-1111-dddd2222eeee"
       } `
   -CertBasedSecurityPrincipal `
       @{
@@ -60,8 +60,8 @@ Creates a new Confidential Ledger.
 ```powershell
 $aadSecurityPrincipal = New-AzConfidentialLedgerAADBasedSecurityPrincipalObject `
   -LedgerRoleName "Administrator" `
-  -PrincipalId "00001111-aaaa-2222-bbbb-3333cccc4444" `
-  -TenantId "00001111-aaaa-2222-bbbb-3333cccc4444"
+  -PrincipalId "ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0" `
+  -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee"
 
 $certSecurityPrincipal = New-AzConfidentialLedgerCertBasedSecurityPrincipalObject `
   -Cert "-----BEGIN CERTIFICATE-----********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************-----END CERTIFICATE-----" `

--- a/azps-13.0.0/Az.ConfidentialLedger/New-AzConfidentialLedgerAADBasedSecurityPrincipalObject.md
+++ b/azps-13.0.0/Az.ConfidentialLedger/New-AzConfidentialLedgerAADBasedSecurityPrincipalObject.md
@@ -28,8 +28,8 @@ Create an in-memory object for AADBasedSecurityPrincipal.
 ```powershell
 New-AzConfidentialLedgerAADBasedSecurityPrincipalObject `
   -LedgerRoleName "Administrator" `
-  -PrincipalId "00001111-aaaa-2222-bbbb-3333cccc4444" `
-  -TenantId "00001111-aaaa-2222-bbbb-3333cccc4444"
+  -PrincipalId "ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0" `
+  -TenantId "aaaabbbb-0000-cccc-1111-dddd2222eeee"
 ```
 
 ```output

--- a/azps-13.0.0/Az.ConfidentialLedger/Update-AzConfidentialLedger.md
+++ b/azps-13.0.0/Az.ConfidentialLedger/Update-AzConfidentialLedger.md
@@ -46,8 +46,8 @@ Update-AzConfidentialLedger `
   -AadBasedSecurityPrincipal `
       @{
           LedgerRoleName="Administrator"; 
-          PrincipalId="00001111-aaaa-2222-bbbb-3333cccc4444"; 
-          TenantId="00001111-aaaa-2222-bbbb-3333cccc4444"
+          PrincipalId="ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0"; 
+          TenantId="aaaabbbb-0000-cccc-1111-dddd2222eeee"
       } `
   -CertBasedSecurityPrincipal `
       @{


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
