### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 16)

### DIFF
--- a/azps-13.0.0/Az.DataShare/Get-AzDataShareDataSet.md
+++ b/azps-13.0.0/Az.DataShare/Get-AzDataShareDataSet.md
@@ -39,9 +39,9 @@ Get-AzDataShareDataSet -ResourceGroupName "ADS" -AccountName "WikiAds" -ShareNam
 ContainerName  : AdsContainer
 DataSetId      : d2411889-5357-4ca8-8d65-9363e46ef2ed
 ResourceGroup  : ADS
-SubscriptionId : 1834da9b-787a-44f6-ae81-60707ab8c957
+SubscriptionId : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 StorageAccount : AdsStorage
-Id             : /subscriptions/1834da9b-787a-44f6-ae81-60707ab8c957/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/shelltest/shares/share4/dataSets/AdsDataSet
+Id             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/shelltest/shares/share4/dataSets/AdsDataSet
 Name           : AdsDataSet
 Type           : Microsoft.DataShare/DataSets
 ```

--- a/azps-13.0.0/Az.DataShare/Get-AzDataShareDataSetMapping.md
+++ b/azps-13.0.0/Az.DataShare/Get-AzDataShareDataSetMapping.md
@@ -41,10 +41,10 @@ ContainerName        : testing
 Prefix               : providercontainer
 DataSetId            : 372899d4-5e67-4c85-bc60-21168b484424
 ResourceGroup        : ADS
-SubscriptionId       : 4834da9b-787a-44f6-ae81-60707ab8c957
+SubscriptionId       : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 StorageAccount       : storageaccount
 DataSetMappingStatus : Ok
-Id                   : /subscriptions/4834da9b-787a-44f6-ae81-60707ab8c957/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/WikiAdsAccount/shareSubscriptions/WikiADS/dataSetMappings/dsm
+Id                   : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/WikiAdsAccount/shareSubscriptions/WikiADS/dataSetMappings/dsm
 Name                 : dsm
 Type                 : Microsoft.DataShare/DataSetMappings
 ```

--- a/azps-13.0.0/Az.DataShare/New-AzDataShareDataSet.md
+++ b/azps-13.0.0/Az.DataShare/New-AzDataShareDataSet.md
@@ -54,9 +54,9 @@ New-AzDataShareDataSet -ResourceGroupName "ADS" -AccountName "WikiAds" -ShareNam
 ContainerName  : AdsContainer
 DataSetId      : d2411889-5357-4ca8-8d65-9363e46ef2ed
 ResourceGroup  : ADS
-SubscriptionId : 1834da9b-787a-44f6-ae81-60707ab8c957
+SubscriptionId : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 StorageAccount : AdsStorage
-Id             : /subscriptions/1834da9b-787a-44f6-ae81-60707ab8c957/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/shelltest/shares/share4/dataSets/AdsDataSet
+Id             : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/shelltest/shares/share4/dataSets/AdsDataSet
 Name           : AdsDataSet
 Type           : Microsoft.DataShare/DataSets
 ```

--- a/azps-13.0.0/Az.DataShare/New-AzDataShareDataSetMapping.md
+++ b/azps-13.0.0/Az.DataShare/New-AzDataShareDataSetMapping.md
@@ -49,10 +49,10 @@ New-AzDataShareDataSetMapping -ResourceGroupName "ADS" -AccountName "WikiAdsAcco
 ContainerName        : AdsContainer
 DataSetId            : 372899d4-5e67-4c85-bc60-21168b484424
 ResourceGroup        : ADS
-SubscriptionId       : 4834da9b-787a-44f6-ae81-60707ab8c957
+SubscriptionId       : aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 StorageAccount       : AdsStorage
 DataSetMappingStatus : Ok
-Id                   : /subscriptions/4834da9b-787a-44f6-ae81-60707ab8c957/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/WikiAdsAccount/shareSubscriptions/AdsShareSubscription/dataSetMappings/AdsDataSetMapping
+Id                   : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/ADS/providers/Microsoft.DataShare/accounts/WikiAdsAccount/shareSubscriptions/AdsShareSubscription/dataSetMappings/AdsDataSetMapping
 Name                 : AdsDataSetMapping
 Type                 : Microsoft.DataShare/DataSetMappings
 ```


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
