### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 20)

### DIFF
--- a/azps-13.0.0/Az.Functions/Get-AzFunctionApp.md
+++ b/azps-13.0.0/Az.Functions/Get-AzFunctionApp.md
@@ -51,8 +51,8 @@ Get-AzFunctionApp
 ```output
 Name                     Status  OSType  Runtime Location    AppServicePlan ResourceGroupName         SubscriptionId
 ----                     ------  ------  ------- --------    -------------- -----------------         --------------
-Functions1-Windows-DoNet Running Windows DotNet  Central US  CentralUSPlan  Functions-West-Europe-Win fe16564a-d943-4bf8-8c28-cf01708c3f8b
-Functions1-Windows-Java  Running Windows Java    West Europe Premium1-WE    Functions-West-Europe1    fe16564a-d943-4bf8-8c28-cf01708c3f8b
+Functions1-Windows-DoNet Running Windows DotNet  Central US  CentralUSPlan  Functions-West-Europe-Win aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
+Functions1-Windows-Java  Running Windows Java    West Europe Premium1-WE    Functions-West-Europe1    aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ### Example 2: Get function apps by name.
@@ -63,7 +63,7 @@ Get-AzFunctionApp -ResourceGroupName Functions-West-Europe-Win -Name Functions1-
 ```output
 Name                     Status  OSType  Runtime Location   AppServicePlan ResourceGroupName         SubscriptionId
 ----                     ------  ------  ------- --------   -------------- -----------------         --------------
-Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win fe16564a-d943-4bf8-8c28-cf01708c3f8b
+Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ### Example 3: Get function apps by resource group name.
@@ -74,18 +74,18 @@ Get-AzFunctionApp -ResourceGroupName Functions-West-Europe-Win
 ```output
 Name                     Status  OSType  Runtime Location   AppServicePlan ResourceGroupName         SubscriptionId
 ----                     ------  ------  ------- --------   -------------- -----------------         --------------
-Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win fe16564a-d943-4bf8-8c28-cf01708c3f8b
+Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ### Example 4: Get function apps for the given subscriptions.
 ```powershell
-Get-AzFunctionApp -SubscriptionId fe16564a-d943-4bf8-8c28-cf01708c3f8b
+Get-AzFunctionApp -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
 Name                     Status  OSType  Runtime Location   AppServicePlan ResourceGroupName         SubscriptionId
 ----                     ------  ------  ------- --------   -------------- -----------------         --------------
-Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win fe16564a-d943-4bf8-8c28-cf01708c3f8b
+Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ### Example 5: Get function apps by location.
@@ -96,7 +96,7 @@ Get-AzFunctionApp -Location "Central US"
 ```output
 Name                     Status  OSType  Runtime Location   AppServicePlan ResourceGroupName         SubscriptionId
 ----                     ------  ------  ------- --------   -------------- -----------------         --------------
-Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win fe16564a-d943-4bf8-8c28-cf01708c3f8b
+Functions1-Windows-DoNet Running Windows DotNet  Central US CentralUSPlan  Functions-West-Europe-Win aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ## PARAMETERS

--- a/azps-13.0.0/Az.Functions/Get-AzFunctionAppPlan.md
+++ b/azps-13.0.0/Az.Functions/Get-AzFunctionAppPlan.md
@@ -79,13 +79,13 @@ This command gets function app plans by resource group name.
 
 ### Example 3: Get function app plans for the given subscriptions.
 ```powershell
-Get-AzFunctionAppPlan -SubscriptionId fe16564a-d943-4bf8-8c28-cf01708c3f8z
+Get-AzFunctionAppPlan -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
 Name                               WorkerType SkuTier        SkuName Location    ResourceGroupName                SubscriptionId
 ----                               ---------- -------        ------- --------    -----------------                --------------
-Func99-West-Europe-Windows-Premium Windows    ElasticPremium EP1     West Europe Func99-West-Europe-Win-Premium   fe16564a-d943-4bf8-8c28-cf01708c3f8z
+Func99-West-Europe-Windows-Premium Windows    ElasticPremium EP1     West Europe Func99-West-Europe-Win-Premium   aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 This command gets function app plans for the given subscriptions.


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
