### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 21)

### DIFF
--- a/azps-13.0.0/Az.Informatica/New-AzInformaticaOrganization.md
+++ b/azps-13.0.0/Az.Informatica/New-AzInformaticaOrganization.md
@@ -51,7 +51,7 @@ Create a InformaticaOrganizationResource
 
 ### Example 1: Create new Informatica Resource
 ```powershell
-New-AzInformaticaOrganization -Name "NewInformaticaTestResource" -ResourceGroupName "InformaticaTestRg" -Location "westus2" -SubscriptionId "ce37d538-dfa3-49c3-b3cd-149b4b7db48a"  -CompanyDetailCompanyName "Test" -CompanyDetailCountry "India" -CompanyDetailDomain "" -CompanyDetailNumberOfEmployee 0  -BusinessPhoneNumber ""  -MarketplaceDetailMarketplaceSubscriptionId "c948d31a-c011-4b16-ce29-688c1565fc06" -OfferDetailOfferId "prod-idmc_as_azure_native_isv_service" -OfferDetailPlanId "prod-private_priview_plan_cdi_free" -OfferDetailPlanName "Pay as you go" -OfferDetailPublisherId "informatica" -OfferDetailTermId "zwuaefo5ywwo" -OfferDetailTermUnit "P1Y" -UserDetailEmailAddress "Test_Infa@mpliftrlogz20210811outlook.onmicrosoft.com" -UserDetailFirstName "Test" -UserDetailLastName "Test" -UserDetailPhoneNumber "9876543210" -UserDetailUpn "Test_Infa@mpliftrlogz20210811outlook.onmicrosoft.com"
+New-AzInformaticaOrganization -Name "NewInformaticaTestResource" -ResourceGroupName "InformaticaTestRg" -Location "westus2" -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"  -CompanyDetailCompanyName "Test" -CompanyDetailCountry "India" -CompanyDetailDomain "" -CompanyDetailNumberOfEmployee 0  -BusinessPhoneNumber ""  -MarketplaceDetailMarketplaceSubscriptionId "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f" -OfferDetailOfferId "prod-idmc_as_azure_native_isv_service" -OfferDetailPlanId "prod-private_priview_plan_cdi_free" -OfferDetailPlanName "Pay as you go" -OfferDetailPublisherId "informatica" -OfferDetailTermId "zwuaefo5ywwo" -OfferDetailTermUnit "P1Y" -UserDetailEmailAddress "Test_Infa@mpliftrlogz20210811outlook.onmicrosoft.com" -UserDetailFirstName "Test" -UserDetailLastName "Test" -UserDetailPhoneNumber "9876543210" -UserDetailUpn "Test_Infa@mpliftrlogz20210811outlook.onmicrosoft.com"
 ```
 
 ```output
@@ -61,7 +61,7 @@ CompanyDetailCountry                       : India
 CompanyDetailDomain                        :
 CompanyDetailNumberOfEmployee              : 0
 CompanyDetailOfficeAddress                 :
-Id                                         : /subscriptions/ce37d538-dfa3-49c3-b3cd-149b4b7db48a/resourceGroups/InformaticaTestRg/providers/Informatica.DataManagement/organizations/NewInformaticaTestResource
+Id                                         : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/InformaticaTestRg/providers/Informatica.DataManagement/organizations/NewInformaticaTestResource
 InformaticaPropertyInformaticaRegion       :
 InformaticaPropertyOrganizationId          :
 InformaticaPropertyOrganizationName        :

--- a/azps-13.0.0/Az.Informatica/Remove-AzInformaticaOrganization.md
+++ b/azps-13.0.0/Az.Informatica/Remove-AzInformaticaOrganization.md
@@ -34,7 +34,7 @@ Delete a InformaticaOrganizationResource
 
 ### Example 1: Remove Informatica Organization
 ```powershell
-Remove-AzInformaticaOrganization -Name "InformaticaTestResource" -ResourceGroupName "InformaticaTestRg" -SubscriptionId "ce37d538-dfa3-49c3-b3cd-149b4b7db48a"
+Remove-AzInformaticaOrganization -Name "InformaticaTestResource" -ResourceGroupName "InformaticaTestRg" -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 ```
 
 ```output

--- a/azps-13.0.0/Az.Informatica/Update-AzInformaticaOrganization.md
+++ b/azps-13.0.0/Az.Informatica/Update-AzInformaticaOrganization.md
@@ -49,7 +49,7 @@ Update a InformaticaOrganizationResource
 
 ### Example 1: Update Informatica Organization
 ```powershell
-Update-AzInformaticaOrganization -Name "InformaticaTestResource" -ResourceGroupName "InformaticaTestRg" -SubscriptionId "ce37d538-dfa3-49c3-b3cd-149b4b7db48a" -Property @{
+Update-AzInformaticaOrganization -Name "InformaticaTestResource" -ResourceGroupName "InformaticaTestRg" -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Property @{
     userDetails = @{
         firstName = "Test"
         lastName = ""
@@ -85,7 +85,7 @@ CompanyDetailCountry                       : India
 CompanyDetailDomain                        :
 CompanyDetailNumberOfEmployee              : 0
 CompanyDetailOfficeAddress                 :
-Id                                         : /subscriptions/ce37d538-dfa3-49c3-b3cd-149b4b7db48a/resourceGroups/InformaticaTestRg/providers/Informatica.DataManagement/organizations/InformaticaTestResource
+Id                                         : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourceGroups/InformaticaTestRg/providers/Informatica.DataManagement/organizations/InformaticaTestResource
 InformaticaPropertyInformaticaRegion       :
 InformaticaPropertyOrganizationId          :
 InformaticaPropertyOrganizationName        :


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
