### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 28)

### DIFF
--- a/azps-13.0.0/Az.Marketplace/Get-AzMarketplaceCollectionToSubscriptionMapping.md
+++ b/azps-13.0.0/Az.Marketplace/Get-AzMarketplaceCollectionToSubscriptionMapping.md
@@ -60,7 +60,7 @@ For a given subscriptions list, the API will return a map of collections and the
 
 ### Example 1: Map subscriptions to collections
 ```powershell
-$res = Get-AzMarketplaceCollectionToSubscriptionMapping -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -Payload @{SubscriptionId = "53425a7b-4ac1-4729-8340-e1da5046212c"}
+$res = Get-AzMarketplaceCollectionToSubscriptionMapping -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -Payload @{SubscriptionId = "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"}
 $res.keys
 ```
 

--- a/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreCollectionMapOffersToContext.md
+++ b/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreCollectionMapOffersToContext.md
@@ -27,7 +27,7 @@ Get a list of all offers in the given collection according to the required conte
 
 ### Example 1: Map offers to subscriptions
 ```powershell
-Get-AzMarketplacePrivateStoreCollectionMapOffersToContext -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -CollectionId a260d38c-96cf-492d-a340-404d0c4b3ad6 -SubscriptionId 1f58b5dd-313c-42ed-84fc-f1e351bba7fb,ab3de7bc-7a6e-4e9f-a34a-f6922df453e4
+Get-AzMarketplacePrivateStoreCollectionMapOffersToContext -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -CollectionId a260d38c-96cf-492d-a340-404d0c4b3ad6 -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e,bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f
 ```
 
 Get a list of all offers in the given collection according to the required subscriptions.

--- a/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreOffer.md
+++ b/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreOffer.md
@@ -62,7 +62,7 @@ Get private store's offers with private + public plans  that were added under te
 
 ### Example 2
 ```powershell
-Get-AzMarketplacePrivateStoreOffer -PrivateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -SubscriptionId bc17bb69-1264-4f90-a9f6-0e51e29d5281
+Get-AzMarketplacePrivateStoreOffer -PrivateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
@@ -74,7 +74,7 @@ PrivateStoreId            : 7gh67884-1r56-44fb-a93d-030d4ae08b2d
 CreatedBy                 :
 CreatedDate               : 01/01/0001 00:00:00
 SpecificPlanIdsLimitation : {large-pr, small-pr}
-Id                        : /subscriptions/bc17bb69-1264-4f90-a9f6-0e51e29d5281/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
+Id                        : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
                             publisherid.offerid
 Name                      : publisherid.offerid
 Type                      : Microsoft.Marketplace/privateStores/offers
@@ -87,7 +87,7 @@ PrivateStoreId            : 7gh67884-1r56-44fb-a93d-030d4ae08b2d
 CreatedBy                 :
 CreatedDate               : 01/01/0001 00:00:00
 SpecificPlanIdsLimitation : {azure_managedservices_professional-pr}
-Id                        : /subscriptions/bc17bb69-1264-4f90-a9f6-0e51e29d5281/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
+Id                        : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
                             publisherid1.offerid1
 Name                      : publisherid1.offerid1
 Type                      : Microsoft.Marketplace/privateStores/offers
@@ -119,7 +119,7 @@ Get  private store's offer with private + public plans that was been added under
 
 ### Example 4
 ```powershell
-Get-AzMarketplacePrivateStoreOffer -PrivateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -OfferId publisherid.offerid -SubscriptionId bc17bb69-1264-4f90-a9f6-0e51e29d5281
+Get-AzMarketplacePrivateStoreOffer -PrivateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -OfferId publisherid.offerid -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
@@ -131,7 +131,7 @@ PrivateStoreId            : 7gh67884-1r56-44fb-a93d-030d4ae08b2d
 CreatedBy                 :
 CreatedDate               : 01/01/0001 00:00:00
 SpecificPlanIdsLimitation : {large-pr, small-pr}
-Id                        : /subscriptions/bc17bb69-1264-4f90-a9f6-0e51e29d5281/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
+Id                        : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
                             publisherid.offerid
 Name                      : publisherid.offerid
 Type                      : Microsoft.Marketplace/privateStores/offers

--- a/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreUserOffer.md
+++ b/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreUserOffer.md
@@ -35,7 +35,7 @@ List of user's approved offers for the provided offers and subscriptions
 
 ### Example 1: List all approved offers for a user
 ```powershell
-Get-AzMarketplacePrivateStoreUserOffer -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -OfferId aumatics.azure_managedservices -SubscriptionId 1f58b5dd-313c-42ed-84fc-f1e351bba7fb
+Get-AzMarketplacePrivateStoreUserOffer -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -OfferId aumatics.azure_managedservices -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 List of user's approved offers for the provided offers and subscriptions.

--- a/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreUserRule.md
+++ b/azps-13.0.0/Az.Marketplace/Get-AzMarketplacePrivateStoreUserRule.md
@@ -33,7 +33,7 @@ All rules approved in the private store that are relevant for user subscriptions
 
 ### Example 1: Get all applied rules for user subscriptions
 ```powershell
-Get-AzMarketplacePrivateStoreUserRule -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -SubscriptionId 1f58b5dd-313c-42ed-84fc-f1e351bba7fb
+Get-AzMarketplacePrivateStoreUserRule -PrivateStoreId a260d38c-96cf-492d-a340-404d0c4b3ad6 -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 All rules approved in the private store that are relevant for user subscriptions.

--- a/azps-13.0.0/Az.Marketplace/Set-AzMarketplacePrivateStoreOffer.md
+++ b/azps-13.0.0/Az.Marketplace/Set-AzMarketplacePrivateStoreOffer.md
@@ -35,7 +35,7 @@ Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4
 UniqueOfferId             : publisherid.offerid
 OfferDisplayName          :
 PublisherDisplayName      :
-ETag                      : "04009562-0000-0600-0000-5ecd2fb00000"
+ETag                      : "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 PrivateStoreId            : 7gh67884-1r56-44fb-a93d-030d4ae08b2d
 CreatedBy                 :
 CreatedDate               : 01/01/0001 00:00:00
@@ -50,19 +50,19 @@ Creates offer with private + public plans for private store that was created und
 
 ### Example 2
 ```powershell
-Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -offerId  publisherid.offerid -SubscriptionId bc17bb69-1264-4f90-a9f6-0e51e29d5281 -SpecificPlanIdsLimitation @("PublisherEnterpriseLinux72", "PublisherEnterpriseLinux72-ARM", "PublisherEnterpriseLinux73", "PublisherEnterpriseLinux73-ARM ", "PublisherEnterpriseLinux73-ARM-pr")
+Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -offerId  publisherid.offerid -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -SpecificPlanIdsLimitation @("PublisherEnterpriseLinux72", "PublisherEnterpriseLinux72-ARM", "PublisherEnterpriseLinux73", "PublisherEnterpriseLinux73-ARM ", "PublisherEnterpriseLinux73-ARM-pr")
 ```
 
 ```output
 UniqueOfferId             : publisherid.offerid
 OfferDisplayName          :
 PublisherDisplayName      :
-ETag                      : "04009562-0000-0600-0000-5ecd2fb00000"
+ETag                      : "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 PrivateStoreId            : 7gh67884-1r56-44fb-a93d-030d4ae08b2d
 CreatedBy                 :
 CreatedDate               : 01/01/0001 00:00:00
 SpecificPlanIdsLimitation : {PublisherEnterpriseLinux73-ARM-pr}
-Id                        : /subscriptions/bc17bb69-1264-4f90-a9f6-0e51e29d5281/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
+Id                        : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
                             publisherid.offerid
 Name                      : publisherid.offerid
 Type                      : Microsoft.Marketplace/privateStores/offers
@@ -72,7 +72,7 @@ Creates offer with private plans only for private store that was created under s
 
 ### Example 3
 ```powershell
-Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -offerId  publisherid.offerid -SpecificPlanIdsLimitation @("PublisherEnterpriseLinux72", "PublisherEnterpriseLinux72-ARM", "PublisherEnterpriseLinux73") -ETag 04009562-0000-0600-0000-5ecd2fb00000
+Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -offerId  publisherid.offerid -SpecificPlanIdsLimitation @("PublisherEnterpriseLinux72", "PublisherEnterpriseLinux72-ARM", "PublisherEnterpriseLinux73") -ETag bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f
 ```
 
 ```output
@@ -94,7 +94,7 @@ Updates offer with private + public plans for private store that was created und
 
 ### Example 4
 ```powershell
-Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -offerId  publisherid.offerid -SubscriptionId bc17bb69-1264-4f90-a9f6-0e51e29d5281 -SpecificPlanIdsLimitation @("PublisherEnterpriseLinux73-pr") -ETag 04009562-0000-0600-0000-5ecd2fb00000
+Set-AzMarketplacePrivateStoreOffer -privateStoreId 7gh67884-1r56-44fb-a93d-030d4ae08b2d -offerId  publisherid.offerid -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e -SpecificPlanIdsLimitation @("PublisherEnterpriseLinux73-pr") -ETag bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f
 ```
 
 ```output
@@ -106,7 +106,7 @@ PrivateStoreId            : 7gh67884-1r56-44fb-a93d-030d4ae08b2d
 CreatedBy                 :
 CreatedDate               : 01/01/0001 00:00:00
 SpecificPlanIdsLimitation : {PublisherEnterpriseLinux73-pr}
-Id                        : /subscriptions/bc17bb69-1264-4f90-a9f6-0e51e29d5281/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
+Id                        : /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/providers/Microsoft.Marketplace/privateStores/7gh67884-1r56-44fb-a93d-030d4ae08b2d/offers/
                             publisherid.offerid
 Name                      : publisherid.offerid
 Type                      : Microsoft.Marketplace/privateStores/offers


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
