### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 29)

### DIFF
--- a/azps-13.0.0/Az.Migrate/Get-AzMigrateRunAsAccount.md
+++ b/azps-13.0.0/Az.Migrate/Get-AzMigrateRunAsAccount.md
@@ -40,20 +40,20 @@ Get-AzMigrateRunAsAccount  -SubscriptionId xxx-xxx-xxx -ResourceGroupName BugBas
 ```output
 Name                                 Type
 ----                                 ----
-b090bef3-b733-5e34-bc8f-eb6f2701432a Microsoft.OffAzure/VMwareSites/runasaccounts
+aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e Microsoft.OffAzure/VMwareSites/runasaccounts
 ```
 
 List all run as accounts in a site.
 
 ### Example 2: Get
 ```powershell
-Get-AzMigrateRunAsAccount  -SubscriptionId xxx-xxx-xxx -ResourceGroupName BugBashAVSVMware -SiteName BBVMwareAVScbbcsite -AccountName b090bef3-b733-5e34-bc8f-eb6f2701432a
+Get-AzMigrateRunAsAccount  -SubscriptionId xxx-xxx-xxx -ResourceGroupName BugBashAVSVMware -SiteName BBVMwareAVScbbcsite -AccountName aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ```output
 Name                                 Type
 ----                                 ----
-b090bef3-b733-5e34-bc8f-eb6f2701432a Microsoft.OffAzure/VMwareSites/runasaccounts
+aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e Microsoft.OffAzure/VMwareSites/runasaccounts
 ```
 
 Get Run as account by name.

--- a/azps-13.0.0/Az.Migrate/New-AzMigrateHCIServerReplication.md
+++ b/azps-13.0.0/Az.Migrate/New-AzMigrateHCIServerReplication.md
@@ -52,10 +52,10 @@ EndTime                            : 1/1/1900 8:54:47 PM
 Error                              : {}
 Id                                 : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/jobs/f2d3430a-2977-419f-abd5-11d171e17f5e
 Name                               : f2d3430a-2977-419f-abd5-11d171e17f5e
-ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/0ec082d5-6827-457a-bae2-f986e1b94555     
+ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb     
 ObjectInternalId                   : a8b5ee68-102c-5aae-9499-c57a475a8fd4
 ObjectInternalName                 : test_vm
-ObjectName                         : 0ec082d5-6827-457a-bae2-f986e1b94555
+ObjectName                         : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectType                         : ProtectedItem
 ReplicationProviderId              : xxx-xxx-xxx
 SourceFabricProviderId             : b35da11c-d69e-4220-9a90-d81ed93ad2fc
@@ -78,13 +78,13 @@ This is for the scenario, when there is only one single disk that has to be prot
 ### Example 2: When there are multiple disks or NICs to migrate
 ```powershell
 [AzStackHCIDiskInput[]]$DisksToInclude = @()
-$OSDisk = New-AzMigrateHCIDiskMappingObject -DiskID "Microsoft:C1A34301-3BFF-4EC6-97F1-6C4BD5ADCDE0\83F8638B-8DCA-4152-9EDA-2CA8B33039B4\0\0\L" -IsOSDisk true -IsDynamic true -Size 42 -Format VHD
-$DataDisk = New-AzMigrateHCIDiskMappingObject -DiskID "Microsoft:C1A34301-3BFF-4EC6-97F1-6C4BD5ADCDE0\C92FAB89-DA8B-47E9-92F3-364642ECDF39\0\0\L" -IsOSDisk false -IsDynamic true -Size 5 -Format VHD
+$OSDisk = New-AzMigrateHCIDiskMappingObject -DiskID "Microsoft:bbbbbbbb-1111-2222-3333-cccccccccccc\83F8638B-8DCA-4152-9EDA-2CA8B33039B4\0\0\L" -IsOSDisk true -IsDynamic true -Size 42 -Format VHD
+$DataDisk = New-AzMigrateHCIDiskMappingObject -DiskID "Microsoft:bbbbbbbb-1111-2222-3333-cccccccccccc\C92FAB89-DA8B-47E9-92F3-364642ECDF39\0\0\L" -IsOSDisk false -IsDynamic true -Size 5 -Format VHD
 $DisksToInclude += $OSDisk
 $DisksToInclude += $DataDisk
 
 [AzStackHCINicInput[]]$NicsToInclude = @()
-$Nic = New-AzMigrateHCINicMappingObject -NicID "Microsoft:C1A34301-3BFF-4EC6-97F1-6C4BD5ADCDE0\99CDFD2E-D60C-4218-AC2E-E7C2D8253EB9" -TargetVirtualSwitchId "/subscriptions/xxx-xxx-xxx/resourceGroups/hciclus-rg/providers/Microsoft.AzureStackHCI/logicalnetworks/external"
+$Nic = New-AzMigrateHCINicMappingObject -NicID "Microsoft:bbbbbbbb-1111-2222-3333-cccccccccccc\99CDFD2E-D60C-4218-AC2E-E7C2D8253EB9" -TargetVirtualSwitchId "/subscriptions/xxx-xxx-xxx/resourceGroups/hciclus-rg/providers/Microsoft.AzureStackHCI/logicalnetworks/external"
 $NicsToInclude += $Nic
 
 New-AzMigrateHCIServerReplication -MachineId "/subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.OffAzure/HyperVSites/testsrc7972site/machines/005-005-005" -TargetStoragePathId "/subscriptions/xxx-xxx-xxx/resourceGroups/hciclus-rg/providers/Microsoft.AzureStackHCI/storagecontainers/testStorageContainer1" -TargetResourceGroupId "/subscriptions//xxx-xxx-xxx/resourceGroups/target-rg"-TargetVMName "targetVM" -DiskToInclude $DisksToInclude -NicToInclude $NicsToInclude
@@ -100,10 +100,10 @@ EndTime                            : 1/1/1900 2:27:14 PM
 Error                              : {}
 Id                                 : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/jobs/f855305c-5bed-4bc6-996e-d273115ab833
 Name                               : f855305c-5bed-4bc6-996e-d273115ab833
-ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/c1a34301-3bff-4ec6-97f1-6c4bd5adcde0     
+ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/bbbbbbbb-1111-2222-3333-cccccccccccc     
 ObjectInternalId                   : a40ecd8e-6413-574d-b1f8-2ef925e087fc
 ObjectInternalName                 : test_vm
-ObjectName                         : c1a34301-3bff-4ec6-97f1-6c4bd5adcde0
+ObjectName                         : bbbbbbbb-1111-2222-3333-cccccccccccc
 ObjectType                         : ProtectedItem
 ReplicationProviderId              : 4de0fddc-bdfe-40d9-b60e-678bdce89630
 SourceFabricProviderId             : b35da11c-d69e-4220-9a90-d81ed93ad2fc

--- a/azps-13.0.0/Az.Migrate/Remove-AzMigrateHCIServerReplication.md
+++ b/azps-13.0.0/Az.Migrate/Remove-AzMigrateHCIServerReplication.md
@@ -48,10 +48,10 @@ EndTime                            :
 Error                              : {}
 Id                                 : /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/testproj1234replicationvault/jobs/2b0b356e-d106-43af-ad26-02631fcaebba
 Name                               : 2b0b356e-d106-43af-ad26-02631fcaebba
-ObjectId                           : /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/testproj1234replicationvault/protectedItems/c1a34301-3bff-4ec6-97f1-6c4bd5adcde0
+ObjectId                           : /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/testproj1234replicationvault/protectedItems/aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectInternalId                   : a40ecd8e-6413-574d-b1f8-2ef925e087fc
 ObjectInternalName                 : testmachine
-ObjectName                         : c1a34301-3bff-4ec6-97f1-6c4bd5adcde0
+ObjectName                         : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectType                         : ProtectedItem
 ReplicationProviderId              : 4de0fddc-bdfe-40d9-b60e-678bdce89630
 SourceFabricProviderId             : b35da11c-d69e-4220-9a90-d81ed93ad2fc
@@ -90,10 +90,10 @@ EndTime                            :
 Error                              : {}
 Id                                 : /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/testproj1234replicationvault/jobs/2b0b356e-d106-43af-ad26-02631fcaebba
 Name                               : 2b0b356e-d106-43af-ad26-02631fcaebba
-ObjectId                           : /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/testproj1234replicationvault/protectedItems/c1a34301-3bff-4ec6-97f1-6c4bd5adcde0
+ObjectId                           : /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/testproj1234replicationvault/protectedItems/aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectInternalId                   : a40ecd8e-6413-574d-b1f8-2ef925e087fc
 ObjectInternalName                 : testmachine
-ObjectName                         : c1a34301-3bff-4ec6-97f1-6c4bd5adcde0
+ObjectName                         : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectType                         : ProtectedItem
 ReplicationProviderId              : 4de0fddc-bdfe-40d9-b60e-678bdce89630
 SourceFabricProviderId             : b35da11c-d69e-4220-9a90-d81ed93ad2fc

--- a/azps-13.0.0/Az.Migrate/Set-AzMigrateHCIServerReplication.md
+++ b/azps-13.0.0/Az.Migrate/Set-AzMigrateHCIServerReplication.md
@@ -41,10 +41,10 @@ EndTime                            : 1/1/1900 8:54:47 PM
 Error                              : {}
 Id                                 : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/jobs/f2d3430a-2977-419f-abd5-11d171e17f5e
 Name                               : f2d3430a-2977-419f-abd5-11d171e17f5e
-ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/0ec082d5-6827-457a-bae2-f986e1b94555     
+ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb     
 ObjectInternalId                   : a8b5ee68-102c-5aae-9499-c57a475a8fd4
 ObjectInternalName                 : test_vm
-ObjectName                         : 0ec082d5-6827-457a-bae2-f986e1b94555
+ObjectName                         : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectType                         : ProtectedItem
 ReplicationProviderId              : xxx-xxx-xxx
 SourceFabricProviderId             : b35da11c-d69e-4220-9a90-d81ed93ad2fc
@@ -85,10 +85,10 @@ EndTime                            : 1/1/1900 8:54:47 PM
 Error                              : {}
 Id                                 : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/jobs/f2d3430a-2977-419f-abd5-11d171e17f5e
 Name                               : f2d3430a-2977-419f-abd5-11d171e17f5e
-ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/0ec082d5-6827-457a-bae2-f986e1b94555     
+ObjectId                           : /subscriptions/xxx-xxx-xxx/resourceGroups/test-rg/providers/Microsoft.DataReplication/replicationVaults/proj62434replicationvault/protectedItems/aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb     
 ObjectInternalId                   : a8b5ee68-102c-5aae-9499-c57a475a8fd4
 ObjectInternalName                 : test_vm
-ObjectName                         : 0ec082d5-6827-457a-bae2-f986e1b94555
+ObjectName                         : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ObjectType                         : ProtectedItem
 ReplicationProviderId              : xxx-xxx-xxx
 SourceFabricProviderId             : b35da11c-d69e-4220-9a90-d81ed93ad2fc


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
