### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 35)

### DIFF
--- a/azps-13.0.0/Az.PolicyInsights/Get-AzPolicyEvent.md
+++ b/azps-13.0.0/Az.PolicyInsights/Get-AzPolicyEvent.md
@@ -84,7 +84,7 @@ Gets policy event records generated in the last day for all resources within the
 
 ### Example 2: Get policy events in the specified subscription scope
 ```powershell
-Get-AzPolicyEvent -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5"
+Get-AzPolicyEvent -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 ```
 
 Gets policy event records generated in the last day for all resources within the specified subscription.
@@ -105,42 +105,42 @@ Gets policy event records generated in the last day for all resources within the
 
 ### Example 5: Get policy events in resource group scope in the specified subscription
 ```powershell
-Get-AzPolicyEvent -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -ResourceGroupName "myResourceGroup"
+Get-AzPolicyEvent -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -ResourceGroupName "myResourceGroup"
 ```
 
 Gets policy event records generated in the last day for all resources within the specified resource group (in the specified subscription).
 
 ### Example 6: Get policy events for a resource
 ```powershell
-Get-AzPolicyEvent -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1"
+Get-AzPolicyEvent -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1"
 ```
 
 Gets policy event records generated in the last day for the specified resource.
 
 ### Example 7: Get policy events for a policy set definition in current subscription
 ```powershell
-Get-AzPolicyEvent -PolicySetDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyEvent -PolicySetDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets policy event records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy set definition (that exists in the subscription in current session context).
 
 ### Example 8: Get policy events for a policy set definition in the specified subscription
 ```powershell
-Get-AzPolicyEvent -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicySetDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyEvent -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicySetDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets policy event records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy set definition (that exists in the specified subscription).
 
 ### Example 9: Get policy events for a policy definition in current subscription
 ```powershell
-Get-AzPolicyEvent -PolicyDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyEvent -PolicyDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets policy event records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy definition (that exists in the subscription in current session context).
 
 ### Example 10: Get policy events for a policy definition in the specified subscription
 ```powershell
-Get-AzPolicyEvent -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicyDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyEvent -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicyDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets policy event records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy definition (that exists in the specified subscription).
@@ -154,7 +154,7 @@ Gets policy event records generated in the last day for all resources (within th
 
 ### Example 12: Get policy events for a policy assignment in the specified subscription
 ```powershell
-Get-AzPolicyEvent -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicyAssignmentName "ddd8ef92e3714a5ea3d208c1"
+Get-AzPolicyEvent -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicyAssignmentName "ddd8ef92e3714a5ea3d208c1"
 ```
 
 Gets policy event records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy assignment (that exists in the specified subscription).

--- a/azps-13.0.0/Az.PolicyInsights/Get-AzPolicyState.md
+++ b/azps-13.0.0/Az.PolicyInsights/Get-AzPolicyState.md
@@ -84,7 +84,7 @@ Gets latest policy state records generated in the last day for all resources wit
 
 ### Example 2: Get latest policy states in the specified subscription scope
 ```powershell
-Get-AzPolicyState -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5"
+Get-AzPolicyState -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 ```
 
 Gets latest policy state records generated in the last day for all resources within the specified subscription.
@@ -112,42 +112,42 @@ Gets latest policy state records generated in the last day for all resources wit
 
 ### Example 6: Get latest policy states in resource group scope in the specified subscription
 ```powershell
-Get-AzPolicyState -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -ResourceGroupName "myResourceGroup"
+Get-AzPolicyState -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -ResourceGroupName "myResourceGroup"
 ```
 
 Gets latest policy state records generated in the last day for all resources within the specified resource group (in the specified subscription).
 
 ### Example 7: Get latest policy states for a resource
 ```powershell
-Get-AzPolicyState -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1"
+Get-AzPolicyState -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1"
 ```
 
 Gets latest policy state records generated in the last day for the specified resource.
 
 ### Example 8: Get latest policy states for a policy set definition in current subscription
 ```powershell
-Get-AzPolicyState -PolicySetDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyState -PolicySetDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets latest policy state records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy set definition (that exists in the subscription in current session context).
 
 ### Example 9: Get latest policy states for a policy set definition in the specified subscription
 ```powershell
-Get-AzPolicyState -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicySetDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyState -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicySetDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets latest policy state records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy set definition (that exists in the specified subscription).
 
 ### Example 10: Get latest policy states for a policy definition in current subscription
 ```powershell
-Get-AzPolicyState -PolicyDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyState -PolicyDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets latest policy state records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy definition (that exists in the subscription in current session context).
 
 ### Example 11: Get latest policy states for a policy definition in the specified subscription
 ```powershell
-Get-AzPolicyState -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicyDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyState -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicyDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets latest policy state records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy definition (that exists in the specified subscription).
@@ -161,7 +161,7 @@ Gets latest policy state records generated in the last day for all resources (wi
 
 ### Example 13: Get latest policy states for a policy assignment with the same scope as the specified subscription
 ```powershell
-Get-AzPolicyState -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicyAssignmentName "ddd8ef92e3714a5ea3d208c1"
+Get-AzPolicyState -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicyAssignmentName "ddd8ef92e3714a5ea3d208c1"
 ```
 
 Gets latest policy state records generated in the last day for all resources (within the tenant in current session context) effected by the specified policy assignment (that exists at subscription scope in the specified subscription).
@@ -239,35 +239,35 @@ This generates the top 5 policies with the most number of non-compliant resource
 
 ### Example 22: Get latest policy states including policy evaluation details for a resource
 ```powershell
-Get-AzPolicyState -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1" -Expand "PolicyEvaluationDetails"
+Get-AzPolicyState -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1" -Expand "PolicyEvaluationDetails"
 ```
 
 Gets latest policy state records generated in the last day for the specified resource and expand policyEvaluationDetails.
 
 ### Example 23: Get latest component policy states for a resource (eg. vault) given a resource provider mode policy assignment
 ```powershell
-Get-AzPolicyState -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.KeyVault/vaults/myvault" -Filter "policyAssignmentId eq '/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1'" -Expand "Components(`$filter=ComplianceState eq 'NonCompliant' or ComplianceState eq 'Compliant')"
+Get-AzPolicyState -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.KeyVault/vaults/myvault" -Filter "policyAssignmentId eq '/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1'" -Expand "Components(`$filter=ComplianceState eq 'NonCompliant' or ComplianceState eq 'Compliant')"
 ```
 
 Gets latest component policy state records generated in the last day for the specified resource, given a resource provider mode policy assignment that references a resource provider mode policy definition.
 
 ### Example 24: Get latest component policy states for a resource (eg. vault) given a policy initiative assignment that contains a resource provider mode policy definition
 ```powershell
-Get-AzPolicyState -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.KeyVault/vaults/myvault" -Filter "policyAssignmentId eq '/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1' and policyDefinitionReferenceId eq 'myResourceProviderModeDefinitionReferenceId'" -Expand "Components(`$filter=ComplianceState eq 'NonCompliant' or ComplianceState eq 'Compliant')"
+Get-AzPolicyState -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.KeyVault/vaults/myvault" -Filter "policyAssignmentId eq '/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1' and policyDefinitionReferenceId eq 'myResourceProviderModeDefinitionReferenceId'" -Expand "Components(`$filter=ComplianceState eq 'NonCompliant' or ComplianceState eq 'Compliant')"
 ```
 
 Gets latest component policy state records generated in the last day for the specified resource, given a resource provider mode policy assignment that references an initiative containing a resource provider mode policy definition.
 
 ### Example 25: Get latest component counts by compliance state for a resource (eg. vault) given a resource provider mode policy assignment
 ```powershell
-Get-AzPolicyState -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.KeyVault/vaults/myvault" -Filter "policyAssignmentId eq '/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1'" -Expand "Components(`$filter=ComplianceState eq 'NonCompliant' or ComplianceState eq 'Compliant' or ComplianceState eq 'Conflict';`$apply=groupby((complianceState),aggregate(`$count as count)))"
+Get-AzPolicyState -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.KeyVault/vaults/myvault" -Filter "policyAssignmentId eq '/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1'" -Expand "Components(`$filter=ComplianceState eq 'NonCompliant' or ComplianceState eq 'Compliant' or ComplianceState eq 'Conflict';`$apply=groupby((complianceState),aggregate(`$count as count)))"
 ```
 
 Gets latest component counts generated in the last day grouped by compliance state for the specified resource, given a resource provider mode policy assignment.
 
 ### Example 26: Get policy states for a management group scope policy assignment
 ```powershell
-Get-AzPolicyState -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -Filter "policyAssignmentId eq '/providers/Microsoft.Management/managementGroups/myManagementGroup/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1'"
+Get-AzPolicyState -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -Filter "policyAssignmentId eq '/providers/Microsoft.Management/managementGroups/myManagementGroup/providers/Microsoft.Authorization/policyAssignments/ddd8ef92e3714a5ea3d208c1'"
 ```
 
 Gets latest policy state records generated in the last day for all resources (within the tenant in current session context) in the specified subscription affected by the specified policy assignment (which is assigned to a management group which is an ancestor of the specified subscription).

--- a/azps-13.0.0/Az.PolicyInsights/Get-AzPolicyStateSummary.md
+++ b/azps-13.0.0/Az.PolicyInsights/Get-AzPolicyStateSummary.md
@@ -81,7 +81,7 @@ Gets the summary view of latest policy compliance states generated in the last d
 
 ### Example 2: Get latest non-compliant policy states summary in the specified subscription scope
 ```powershell
-Get-AzPolicyStateSummary -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5"
+Get-AzPolicyStateSummary -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources within the specified subscription.
@@ -102,42 +102,42 @@ Gets the summary view of latest policy compliance states generated in the last d
 
 ### Example 5: Get latest non-compliant policy states summary in resource group scope in the specified subscription
 ```powershell
-Get-AzPolicyStateSummary -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -ResourceGroupName "myResourceGroup"
+Get-AzPolicyStateSummary -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -ResourceGroupName "myResourceGroup"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources within the specified resource group (in the specified subscription).
 
 ### Example 6: Get latest non-compliant policy states summary for a resource
 ```powershell
-Get-AzPolicyStateSummary -ResourceId "/subscriptions/fff10b27-fff3-fff5-fff8-fffbe01e86a5/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1"
+Get-AzPolicyStateSummary -ResourceId "/subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/myResourceGroup/providers/Microsoft.EventHub/namespaces/myns1/eventhubs/eh1/consumergroups/cg1"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for the specified resource.
 
 ### Example 7: Get latest non-compliant policy states summary for a policy set definition in current subscription
 ```powershell
-Get-AzPolicyStateSummary -PolicySetDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyStateSummary -PolicySetDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources (within the tenant in current session context) effected by the specified policy set definition (that exists in the subscription in current session context).
 
 ### Example 8: Get latest non-compliant policy states summary for a policy set definition in the specified subscription
 ```powershell
-Get-AzPolicyStateSummary -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicySetDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyStateSummary -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicySetDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources (within the tenant in current session context) effected by the specified policy set definition (that exists in the specified subscription).
 
 ### Example 9: Get latest non-compliant policy states summary for a policy definition in current subscription
 ```powershell
-Get-AzPolicyStateSummary -PolicyDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyStateSummary -PolicyDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources (within the tenant in current session context) effected by the specified policy definition (that exists in the subscription in current session context).
 
 ### Example 10: Get latest non-compliant policy states summary for a policy definition in the specified subscription
 ```powershell
-Get-AzPolicyStateSummary -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicyDefinitionName "fff58873-fff8-fff5-fffc-fffbe7c9d697"
+Get-AzPolicyStateSummary -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicyDefinitionName "bbbb1b1b-cc2c-dd3d-ee4e-ffffff5f5f5f"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources (within the tenant in current session context) effected by the specified policy definition (that exists in the specified subscription).
@@ -151,7 +151,7 @@ Gets the summary view of latest policy compliance states generated in the last d
 
 ### Example 12: Get latest non-compliant policy states summary for a policy assignment in the specified subscription
 ```powershell
-Get-AzPolicyStateSummary -SubscriptionId "fff10b27-fff3-fff5-fff8-fffbe01e86a5" -PolicyAssignmentName "ddd8ef92e3714a5ea3d208c1"
+Get-AzPolicyStateSummary -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -PolicyAssignmentName "ddd8ef92e3714a5ea3d208c1"
 ```
 
 Gets the summary view of latest policy compliance states generated in the last day for all resources (within the tenant in current session context) effected by the specified policy assignment (that exists in the specified subscription).


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
