### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 43)

### DIFF
--- a/azps-13.0.0/Az.Resources/Remove-AzManagementGroupSubscription.md
+++ b/azps-13.0.0/Az.Resources/Remove-AzManagementGroupSubscription.md
@@ -27,7 +27,7 @@ The **Remove-AzManagementGroupSubscription** cmdlet removes a Subscription from 
 
 ### Example 1: Remove Subscription from a Management Group
 ```powershell
-Remove-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId 2120692d-35c3-44c8-81f5-631fa7351726
+Remove-AzManagementGroupSubscription -GroupName "TestGroup" -SubscriptionId aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e
 ```
 
 ## PARAMETERS

--- a/azps-13.0.0/Az.Resources/Remove-AzRoleAssignment.md
+++ b/azps-13.0.0/Az.Resources/Remove-AzRoleAssignment.md
@@ -139,7 +139,7 @@ Removes a role assignment for john.doe@contoso.com who is assigned to the Reader
 
 ### Example 2
 ```powershell
-Remove-AzRoleAssignment -ObjectId 00001111-aaaa-2222-bbbb-3333cccc4444 -RoleDefinitionName Reader
+Remove-AzRoleAssignment -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -RoleDefinitionName Reader
 ```
 
 Removes the role assignment to the group principal identified by the ObjectId and assigned to the Reader role.

--- a/azps-13.0.0/Az.Resources/Set-AzRoleAssignment.md
+++ b/azps-13.0.0/Az.Resources/Set-AzRoleAssignment.md
@@ -52,7 +52,7 @@ $ConditionVersion = "2.0"
   $Description = "This is a new role assignment for John"
   $Condition = "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:Path] StringEqualsIgnoreCase 'foo_storage_container'"
 
-  $roleAssignment = Get-AzRoleAssignment -Scope "/subscriptions/00001111-aaaa-2222-bbbb-3333cccc4444/resourceGroups/contoso_rg" -PrincipalId "00001111-aaaa-2222-bbbb-3333cccc4444"
+  $roleAssignment = Get-AzRoleAssignment -Scope "/subscriptions/00001111-aaaa-2222-bbbb-3333cccc4444/resourceGroups/contoso_rg" -PrincipalId "ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0"
   $roleAssignment.Description = $Description
   $roleAssignment.Condition = $Condition
   $roleAssignment.ConditionVersion = $ConditionVersion
@@ -69,7 +69,7 @@ RoleAssignmentId   : /providers/Microsoft.Management/managementGroups/1273adef-0
   SignInName         : John.Doe@Contoso.com
   RoleDefinitionName : Owner
   RoleDefinitionId   : 00001111-aaaa-2222-bbbb-3333cccc4444
-  ObjectId           : 00001111-aaaa-2222-bbbb-3333cccc4444
+  ObjectId           : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
   ObjectType         : User
   CanDelegate        : False
   Description        : This is a new role assignment for John
@@ -93,7 +93,7 @@ RoleAssignmentId   : /providers/Microsoft.Management/managementGroups/1273adef-0
   SignInName         : John.Doe@Contoso.com
   RoleDefinitionName : Owner
   RoleDefinitionId   : 00001111-aaaa-2222-bbbb-3333cccc4444
-  ObjectId           : 00001111-aaaa-2222-bbbb-3333cccc4444
+  ObjectId           : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
   ObjectType         : User
   CanDelegate        : False
   Description        : This is a new role assignment for John

--- a/azps-13.0.0/Az.Resources/Update-AzManagementGroup.md
+++ b/azps-13.0.0/Az.Resources/Update-AzManagementGroup.md
@@ -56,7 +56,7 @@ Update-AzManagementGroup -GroupName "TestGroup" -DisplayName "New Display Name"
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : New Display Name
 UpdatedTime       : 2/1/2018 12:03:37 PM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -74,7 +74,7 @@ Update-AzManagementGroup -GroupName "TestGroup" -ParentId "/providers/Microsoft.
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroup
 UpdatedTime       : 2/1/2018 12:03:37 PM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -92,7 +92,7 @@ Get-AzManagementGroup -GroupName "TestGroup" | Update-AzManagementGroup -Display
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestDisplayName
 UpdatedTime       : 2/1/2018 12:03:37 PM
 UpdatedBy         : 64360beb-ffb4-43a8-9314-01aa34db95a9
@@ -111,7 +111,7 @@ Update-AzManagementGroup -GroupName "TestGroup" -ParentObject $parentObject
 Id                : /providers/Microsoft.Management/managementGroups/TestGroup
 Type              : /providers/Microsoft.Management/managementGroups
 Name              : TestGroup
-TenantId          : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId          : aaaabbbb-0000-cccc-1111-dddd2222eeee
 DisplayName       : TestGroupDisplayName
 UpdatedTime       : 2/1/2018 11:16:12 AM
 UpdatedBy         : 00001111-aaaa-2222-bbbb-3333cccc4444

--- a/azps-13.0.0/Az.Resources/Update-AzManagementGroupHierarchySetting.md
+++ b/azps-13.0.0/Az.Resources/Update-AzManagementGroupHierarchySetting.md
@@ -42,7 +42,7 @@ Update-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869b
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : true
 DefaultManagementGroup :
 ```
@@ -56,7 +56,7 @@ Update-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869b
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : false
 DefaultManagementGroup : TestGroup
 ```
@@ -70,7 +70,7 @@ Update-AzManagementGroupHierarchySetting -GroupName c7a87cda-9a66-4920-b0f8-869b
 Id          : /providers/Microsoft.Management/managementGroups/c7a87cda-9a66-4920-b0f8-869baa04efe0/settings/default
 Type        : Microsoft.Management/managementGroups/settings
 Name        : default
-TenantId    : 00001111-aaaa-2222-bbbb-3333cccc4444
+TenantId    : aaaabbbb-0000-cccc-1111-dddd2222eeee
 RequireAuthorizationForGroupCreation : true
 DefaultManagementGroup : TestGroup
 ```


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
