### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 46)

### DIFF
--- a/azps-13.0.0/Az.SelfHelp/Invoke-AzSelfHelpDiscoverySolutionNlpSubscriptionScope.md
+++ b/azps-13.0.0/Az.SelfHelp/Invoke-AzSelfHelpDiscoverySolutionNlpSubscriptionScope.md
@@ -49,7 +49,7 @@ Solution discovery using natural language processing.
 
 ### Example 1: Discover Solution using natural language at subscription scope
 ```powershell
-Invoke-AzSelfHelpDiscoverySolutionNlpSubscriptionScope -SubscriptionId "6bded6d5-a6af-43e1-96d3-bf71f6f5f8ba" -IssueSummary "Billing Issues"
+Invoke-AzSelfHelpDiscoverySolutionNlpSubscriptionScope -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -IssueSummary "Billing Issues"
 ```
 
 ```output


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
