### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 48)

### DIFF
--- a/azps-13.0.0/Az.ServiceLinker/Test-AzServiceLinkerForContainerApp.md
+++ b/azps-13.0.0/Az.ServiceLinker/Test-AzServiceLinkerForContainerApp.md
@@ -44,7 +44,7 @@ IsConnectionAvailable : True
 LinkerName            : postgresql_connection
 ReportEndTimeUtc      : 5/6/2022 8:32:26 AM
 ReportStartTimeUtc    : 5/6/2022 8:32:24 AM
-ResourceId            : /subscriptions/d82d7763-8e12-4f39-a7b6-496a983ec2f4/resourceGroups/servicelinke 
+ResourceId            : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/servicelinke 
                         r-test-group/providers/Microsoft.App/containerApps/servicelinker-app/providers/Mi 
                         crosoft.ServiceLinker/linkers/postgresql_connection
 SourceId              :

--- a/azps-13.0.0/Az.ServiceLinker/Test-AzServiceLinkerForSpringCloud.md
+++ b/azps-13.0.0/Az.ServiceLinker/Test-AzServiceLinkerForSpringCloud.md
@@ -45,7 +45,7 @@ IsConnectionAvailable : True
 LinkerName            : storagetable_404e8
 ReportEndTimeUtc      : 5/6/2022 8:32:26 AM
 ReportStartTimeUtc    : 5/6/2022 8:32:24 AM
-ResourceId            : /subscriptions/d82d7763-8e12-4f39-a7b6-496a983ec2f4/resourceGroups/servicelinke 
+ResourceId            : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/servicelinke 
                         r-test-group/providers/Microsoft.AppPlatform/Spring/servicelinker-springcloud/apps/appconfiguration/deployments/default/providers/Mi 
                         crosoft.ServiceLinker/linkers/storagetable_404e8
 SourceId              :

--- a/azps-13.0.0/Az.ServiceLinker/Test-AzServiceLinkerForWebApp.md
+++ b/azps-13.0.0/Az.ServiceLinker/Test-AzServiceLinkerForWebApp.md
@@ -44,7 +44,7 @@ IsConnectionAvailable : True
 LinkerName            : postgresql_connection
 ReportEndTimeUtc      : 5/6/2022 8:32:26 AM
 ReportStartTimeUtc    : 5/6/2022 8:32:24 AM
-ResourceId            : /subscriptions/d82d7763-8e12-4f39-a7b6-496a983ec2f4/resourceGroups/servicelinke 
+ResourceId            : /subscriptions/a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1/resourceGroups/servicelinke 
                         r-test-group/providers/Microsoft.Web/sites/servicelinker-webapp/providers/Mi 
                         crosoft.ServiceLinker/linkers/postgresql_connection
 SourceId              :


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-powershell/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
