### PR TITLE
Fix alignment issue in example of migrate-az-14.0.0.md

### DIFF
--- a/docs-conceptual/azps-14.1.0/migrate-az-14.0.0.md
+++ b/docs-conceptual/azps-14.1.0/migrate-az-14.0.0.md
@@ -23,11 +23,12 @@ $authHeader = @{
     'Content-Type'  = 'application/json'
     'Authorization' = 'Bearer ' + (Get-AccessToken)
 }
-$respone = Invoke-RestMethod -Method Get -Headers $authHeader -Uri $uri"	"$secureToken = (Get-AzAccessToken).Token
+$respone = Invoke-RestMethod -Method Get -Headers $authHeader -Uri $uri
 ```
 
 #### After
 ```powershell
+$secureToken = (Get-AzAccessToken).Token
 $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Securetoken)
 try {
      $plaintextToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)


### PR DESCRIPTION
# PR Summary
This pull request makes a small update to the PowerShell script in the `docs-conceptual/azps-14.1.0/migrate-az-14.0.0.md` file. The change involves moving the assignment of `$secureToken` to occur after `$respone` initialization for improved code organization.

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist
<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/azure/azps-docs-style-guide
