### PR TITLE
Register azps-100.0.0 moniker for AzClips PowerShell public preview

### DIFF
--- a/azps-100.0.0/Az.Compute/Az.Compute.md
+++ b/azps-100.0.0/Az.Compute/Az.Compute.md
@@ -1,0 +1,23 @@
+---
+Module Name: Az.Compute
+Module Guid: 6c9a0e61-382a-42be-9ccd-1383d0e38112
+Download Help Link: https://learn.microsoft.com/powershell/module/az.compute
+Help Version: 0.1.0
+Locale: en-US
+content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Compute/help
+original_content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Compute/help
+---
+
+# Az.Compute Module
+## Description
+Azure PowerShell - Compute
+
+## Az.Compute Cmdlets
+### [Get-AzVM](Get-AzVM.md)
+Show details for a virtual machine.
+
+### [New-AzVM](New-AzVM.md)
+Create a virtual machine together with its network interface, virtual network, and network security group in a single call.
+
+### [Remove-AzVM](Remove-AzVM.md)
+Delete a virtual machine.

--- a/azps-100.0.0/Az.Compute/Get-AzVM.md
+++ b/azps-100.0.0/Az.Compute/Get-AzVM.md
@@ -1,0 +1,178 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Compute.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Compute
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzVM
+---
+
+# Get-AzVM
+
+## SYNOPSIS
+
+Show details for a virtual machine.
+
+## SYNTAX
+
+### List (Default)
+
+```
+Get-AzVM -ResourceGroupName <string> [-SubscriptionId <string>] [-Profile <string>]
+ [<CommonParameters>]
+```
+
+### Get
+
+```
+Get-AzVM -ResourceGroupName <string> -Name <string> [-SubscriptionId <string>] [-Profile <string>]
+ [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Retrieves the properties of a single virtual machine identified by name within the specified resource group and subscription.
+
+## EXAMPLES
+
+### Get details of a specific VM
+
+Retrieve metadata for the virtual machine `myvm` in resource group `myrg`.
+
+```powershell
+Get-AzVM -SubscriptionId 00000000-0000-0000-0000-000000000000 -ResourceGroupName myrg -Name myvm
+```
+
+### List all VMs in a resource group
+
+Return every virtual machine that lives in `myrg`.
+
+```powershell
+Get-AzVM -SubscriptionId 00000000-0000-0000-0000-000000000000 -ResourceGroupName myrg
+```
+
+## PARAMETERS
+
+### -Name
+
+The name of the virtual machine.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of a saved profile to use for this call instead of the currently-active one. Manage profiles with `Set-AzProfile` / `Get-AzProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceGroupName
+
+The resource group name.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: List
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Azure Subscription Id. Defaults to the active profile's subscription.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Compute.Models.VirtualMachine
+
+One `VirtualMachine` object per matching VM — a single result when `-Name` is supplied (Get mode), an array of results otherwise (List mode). Each includes the ARM resource ID, provisioning state, VM size, and network configuration.
+
+## NOTES
+
+Generated help for compute.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Compute/New-AzVM.md
+++ b/azps-100.0.0/Az.Compute/New-AzVM.md
@@ -1,0 +1,609 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Compute.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Compute
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: New-AzVM
+---
+
+# New-AzVM
+
+## SYNOPSIS
+
+Create a virtual machine together with its network interface, virtual network, and network security group in a single call.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-AzVM -Name <string> -Location <string> -ResourceGroupName <string> -VmSize <string>
+ -AdminUsername <string> -AdminPassword <string> -NetworkInterfaceName <string>
+ -VirtualNetworkName <string> -NetworkSecurityGroupName <string> [-SubscriptionId <string>]
+ [-SubnetNames <string[]>] [-SubnetAddressPrefixes <string[][]>] [-AddressPrefixes <string[]>]
+ [-RuleNames <string[]>] [-RuleDirections <string[]>] [-RuleProtocols <string[]>]
+ [-RulePriorities <int[]>] [-RuleSourceAddressPrefixes <string[]>]
+ [-RuleSourcePortRanges <string[]>] [-RuleDestinationPortRanges <string[]>]
+ [-RuleDestinationAddressPrefixes <string[]>] [-RuleAccesses <string[]>] [-Profile <string>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Provisions the full networking + VM stack as a single operation.
+Creates a virtual network, network security group, network interface, and virtual machine using the supplied names and parameters.
+Use this command when you want a one-shot VM deployment without composing the underlying resources individually.
+
+## EXAMPLES
+
+### Create a VM with its networking stack
+
+Provision a `Standard_D2s_v3` virtual machine named `myvm` in `myrg` (East US) along with a fresh virtual network (`myvnet`), network security group (`mynsg`), and network interface (`mynic`).
+Assign `$adminPassword` from a secure source in your own pipeline before invoking the cmdlet (the value below is a literal placeholder, not a real password).
+
+```powershell
+$adminPassword = 'P@ssw0rd-replace-me!'
+New-AzVM -SubscriptionId 00000000-0000-0000-0000-000000000000 -Name myvm -Location eastus -ResourceGroupName myrg -VmSize Standard_D2s_v3 -AdminUsername azureuser -AdminPassword $adminPassword -NetworkInterfaceName mynic -VirtualNetworkName myvnet -NetworkSecurityGroupName mynsg
+```
+
+## PARAMETERS
+
+### -AddressPrefixes
+
+Address prefixes for the virtual network.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AdminPassword
+
+The administrator password.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -AdminUsername
+
+The administrator username.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Location
+
+Location for all resources.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+The name of the virtual machine.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -NetworkInterfaceName
+
+The network interface name to create.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -NetworkSecurityGroupName
+
+The network security group name to create.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of a saved profile to use for this call instead of the currently-active one. Manage profiles with `Set-AzProfile` / `Get-AzProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceGroupName
+
+The resource group name.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleAccesses
+
+Access types (Allow/Deny) of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleDestinationAddressPrefixes
+
+Destination address prefixes of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleDestinationPortRanges
+
+Destination port ranges of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleDirections
+
+Directions of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleNames
+
+Names of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RulePriorities
+
+Priorities of the security rules.
+
+```yaml
+Type: System.Int32[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleProtocols
+
+Protocols of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleSourceAddressPrefixes
+
+Source address prefixes of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RuleSourcePortRanges
+
+Source port ranges of the security rules.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubnetAddressPrefixes
+
+Address prefixes for each subnet.
+
+```yaml
+Type: System.String[][]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubnetNames
+
+Names of the subnets.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Azure Subscription Id. Defaults to the active profile's subscription.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -VirtualNetworkName
+
+The virtual network name to create.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -VmSize
+
+The size of the virtual machine.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Compute.Models.VirtualMachine
+
+The newly-created `VirtualMachine` object, including its assigned ARM resource ID, provisioning state, size, and network configuration.
+
+## NOTES
+
+Generated help for compute.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Compute/Remove-AzVM.md
+++ b/azps-100.0.0/Az.Compute/Remove-AzVM.md
@@ -1,0 +1,200 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Compute.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Compute
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Remove-AzVM
+---
+
+# Remove-AzVM
+
+## SYNOPSIS
+
+Delete a virtual machine.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Remove-AzVM -Name <string> -ResourceGroupName <string> [-SubscriptionId <string>]
+ [-Profile <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Deletes the named virtual machine from the specified resource group and subscription.
+This operation removes only the VM resource itself; associated disks, network interfaces, and other dependent resources are not deleted.
+
+## EXAMPLES
+
+### Remove a VM
+
+Delete the virtual machine `myvm` from resource group `myrg`. The associated disks and NICs are not removed.
+
+```powershell
+Remove-AzVM -SubscriptionId 00000000-0000-0000-0000-000000000000 -Name myvm -ResourceGroupName myrg
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+The name of the virtual machine.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of a saved profile to use for this call instead of the currently-active one. Manage profiles with `Set-AzProfile` / `Get-AzProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceGroupName
+
+The resource group name.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Azure Subscription Id. Defaults to the active profile's subscription.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+This cmdlet does not emit an object on the pipeline; it only writes progress and status messages via the Information and Verbose streams.
+
+## NOTES
+
+Generated help for compute.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Config/Az.Config.md
+++ b/azps-100.0.0/Az.Config/Az.Config.md
@@ -1,0 +1,29 @@
+---
+Module Name: Az.Config
+Module Guid: 5b70ac45-5011-483b-bf9b-e6584f1f8ef3
+Download Help Link: https://learn.microsoft.com/powershell/module/az.config
+Help Version: 0.1.0
+Locale: en-US
+content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Config/help
+original_content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Config/help
+---
+
+# Az.Config Module
+## Description
+Configuration management cmdlets for Azure PowerShell
+
+## Az.Config Cmdlets
+### [Get-AzConfig](Get-AzConfig.md)
+Retrieve a configuration value.
+
+### [Get-AzConfigInfo](Get-AzConfigInfo.md)
+Display information about valid configuration keys.
+
+### [Get-AzConfigList](Get-AzConfigList.md)
+List all configuration settings.
+
+### [Remove-AzConfig](Remove-AzConfig.md)
+Delete a configuration value.
+
+### [Set-AzConfig](Set-AzConfig.md)
+Set or update a configuration value.

--- a/azps-100.0.0/Az.Config/Get-AzConfig.md
+++ b/azps-100.0.0/Az.Config/Get-AzConfig.md
@@ -1,0 +1,118 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Config.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Config
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzConfig
+---
+
+# Get-AzConfig
+
+## SYNOPSIS
+
+Retrieve a configuration value.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AzConfig -Key <string> [-AsJson] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Get the current value of a configuration setting by key.
+Configuration keys use dot notation (e.g., output.format, core.debug).
+If the key is not found, an error is displayed.
+
+## EXAMPLES
+
+### Get a configuration value
+
+Return the current value of the `output.format` configuration setting.
+
+```powershell
+Get-AzConfig -Key output.format
+```
+
+### Get output as JSON
+
+Return the value formatted as JSON instead of plain text. Useful for piping into `ConvertFrom-Json` in scripts.
+
+```powershell
+Get-AzConfig -Key output.format -AsJson
+```
+
+## PARAMETERS
+
+### -AsJson
+
+Return the configuration value as a JSON string instead of the default plain text. Useful when piping into `ConvertFrom-Json` or capturing structured output for downstream scripts.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Key
+
+Configuration key in dot notation.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.String
+
+The current value of the configuration setting identified by `-Key`. Returned as plain text by default, or as a JSON string when `-AsJson` is supplied (pipe into `ConvertFrom-Json` for structured downstream processing).
+
+## NOTES
+
+Generated help for config.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Config/Get-AzConfigInfo.md
+++ b/azps-100.0.0/Az.Config/Get-AzConfigInfo.md
@@ -1,0 +1,96 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Config.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Config
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzConfigInfo
+---
+
+# Get-AzConfigInfo
+
+## SYNOPSIS
+
+Display information about valid configuration keys.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AzConfigInfo [-KeysOnly] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Show metadata about available configuration keys including their descriptions, default values, and allowed value constraints.
+Use -KeysOnly to show only valid key names.
+
+## EXAMPLES
+
+### Display configuration schema
+
+Show every valid configuration key together with its description, default value, and accepted values.
+
+```powershell
+Get-AzConfigInfo
+```
+
+### Display only key names
+
+List just the valid key identifiers — useful for tab-completion or scripting.
+
+```powershell
+Get-AzConfigInfo -KeysOnly
+```
+
+## PARAMETERS
+
+### -KeysOnly
+
+Return only valid keys.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.String
+
+Descriptive text listing available configuration keys, their purpose, and default values. When `-KeysOnly` is supplied, only the key names are emitted (one per line).
+
+## NOTES
+
+Generated help for config.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Config/Get-AzConfigList.md
+++ b/azps-100.0.0/Az.Config/Get-AzConfigList.md
@@ -1,0 +1,127 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Config.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Config
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzConfigList
+---
+
+# Get-AzConfigList
+
+## SYNOPSIS
+
+List all configuration settings.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Get-AzConfigList [-IncludeDefaults] [-AsJson] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Display all current configuration values.
+By default, only explicitly-set values are shown.
+Use --all to include default values.
+Output can be formatted as JSON for scripting.
+
+## EXAMPLES
+
+### List all configuration
+
+Display every explicitly-set configuration value.
+
+```powershell
+Get-AzConfigList
+```
+
+### List with defaults
+
+Include default values for keys that have not been explicitly set.
+
+```powershell
+Get-AzConfigList -IncludeDefaults
+```
+
+### List as JSON
+
+Format the output as JSON for downstream scripting.
+
+```powershell
+Get-AzConfigList -AsJson
+```
+
+## PARAMETERS
+
+### -AsJson
+
+Return the configuration list as a JSON document instead of the default plain text. Useful when piping into `ConvertFrom-Json` or capturing structured output for downstream scripts.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -IncludeDefaults
+
+Include keys that have not been explicitly set, showing their built-in default values. Without this switch only keys with user-assigned values are listed.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.String
+
+The set of currently-configured `key=value` entries as plain text (one per line), or as a JSON document when `-AsJson` is supplied. Add `-IncludeDefaults` to also emit keys that have not been explicitly set.
+
+## NOTES
+
+Generated help for config.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Config/Remove-AzConfig.md
+++ b/azps-100.0.0/Az.Config/Remove-AzConfig.md
@@ -1,0 +1,166 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Config.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Config
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Remove-AzConfig
+---
+
+# Remove-AzConfig
+
+## SYNOPSIS
+
+Delete a configuration value.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Remove-AzConfig -Key <string> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Remove a configuration setting by key.
+Once deleted, the setting reverts to its default value (if one exists).
+Unknown keys are rejected unless -Force is specified.
+
+## EXAMPLES
+
+### Delete a configuration value
+
+Remove the `output.format` setting. The configuration will revert to its default value (if one exists).
+
+```powershell
+Remove-AzConfig -Key output.format
+```
+
+### Force delete
+
+Use `-Force` to remove an unknown key that is not part of the documented schema.
+
+```powershell
+Remove-AzConfig -Key custom.experimental.flag -Force
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Force
+
+Allow unknown keys.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Key
+
+Configuration key in dot notation.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.String
+
+Status string confirming the operation, in the form `Deleted <key>`.
+
+## NOTES
+
+Generated help for config.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Config/Set-AzConfig.md
+++ b/azps-100.0.0/Az.Config/Set-AzConfig.md
@@ -1,0 +1,187 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Config.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Config
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Set-AzConfig
+---
+
+# Set-AzConfig
+
+## SYNOPSIS
+
+Set or update a configuration value.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-AzConfig -Key <string> -Value <string> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Set a configuration value using dot notation keys.
+If the key already exists, it will be updated.
+Unknown keys are rejected unless -Force is specified.
+
+## EXAMPLES
+
+### Set output format
+
+Update the `output.format` setting to `json` so that subsequent commands emit JSON output by default.
+
+```powershell
+Set-AzConfig -Key output.format -Value json
+```
+
+### Set custom key with force
+
+Use `-Force` to set a key that is not in the documented configuration schema.
+
+```powershell
+Set-AzConfig -Key custom.experimental.flag -Value enabled -Force
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Force
+
+Allow unknown keys.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Key
+
+Configuration key in dot notation.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Value
+
+Configuration value.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.String
+
+Status string confirming the operation, in the form `Set <key> = <value>`.
+
+## NOTES
+
+Generated help for config.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Login/Az.Login.md
+++ b/azps-100.0.0/Az.Login/Az.Login.md
@@ -1,0 +1,29 @@
+---
+Module Name: Az.Login
+Module Guid: 4a689b34-4900-472a-ae8a-f5473e0e7df2
+Download Help Link: https://learn.microsoft.com/powershell/module/az.login
+Help Version: 0.1.0
+Locale: en-US
+content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Login/help
+original_content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Login/help
+---
+
+# Az.Login Module
+## Description
+Azure authentication cmdlets for Azure PowerShell
+
+## Az.Login Cmdlets
+### [Connect-AzAccount](Connect-AzAccount.md)
+Authenticate to Azure.
+
+### [Disconnect-AzAccount](Disconnect-AzAccount.md)
+Sign out from the current Azure account context.
+
+### [Get-AzProfile](Get-AzProfile.md)
+Gets the saved profiles, or the active profile if -Active is specified.
+
+### [Remove-AzProfile](Remove-AzProfile.md)
+Removes a saved profile by name.
+
+### [Set-AzProfile](Set-AzProfile.md)
+Sets the active profile by name.

--- a/azps-100.0.0/Az.Login/Connect-AzAccount.md
+++ b/azps-100.0.0/Az.Login/Connect-AzAccount.md
@@ -1,0 +1,317 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Login.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Login
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Connect-AzAccount
+---
+
+# Connect-AzAccount
+
+## SYNOPSIS
+
+Authenticate to Azure.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Connect-AzAccount [-SubscriptionId <string>] [-TenantId <string>] [-UseDeviceCode]
+ [-OutProfile <string>] [-Profile <string>] [-Identity] [-ClientId <string>] [-ObjectId <string>]
+ [-ResourceId <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Authenticate to Azure and persist account context for subsequent commands.
+
+## EXAMPLES
+
+### Sign in with the default browser flow
+
+Launches the interactive browser sign-in experience and persists the resulting account context for the specified subscription. Use this on a workstation with a default browser available.
+
+```powershell
+Connect-AzAccount -SubscriptionId '00000000-0000-0000-0000-000000000000' -TenantId '11111111-1111-1111-1111-111111111111'
+```
+
+### Sign in with device code on a host without a browser
+
+Uses the device-code authentication flow — prints a code and verification URL to the console so you can complete the sign-in from another device. Useful for SSH sessions, containers, and headless build agents.
+
+```powershell
+Connect-AzAccount -SubscriptionId '00000000-0000-0000-0000-000000000000' -TenantId '11111111-1111-1111-1111-111111111111' -UseDeviceCode
+```
+
+## PARAMETERS
+
+### -ClientId
+
+Client ID of the user-assigned managed identity to authenticate as. Use with `-Identity`. Mutually exclusive with `-ObjectId` and `-ResourceId`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- AccountId
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Identity
+
+Sign in using a managed identity. System-assigned by default; combine with `-ClientId`, `-ObjectId`, or `-ResourceId` to select a specific user-assigned identity.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- MSI
+- ManagedIdentity
+- ManagedService
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ObjectId
+
+Object (principal) ID of the user-assigned managed identity. Use with `-Identity`. Mutually exclusive with `-ClientId` and `-ResourceId`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -OutProfile
+
+Name of a new named profile in which to persist the sign-in context. Use `-Profile <name>` on subsequent invocations to switch back to it. Mutually exclusive with `-Profile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of an existing named profile to sign into. Mutually exclusive with `-OutProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceId
+
+Full ARM resource ID of the user-assigned managed identity (`/subscriptions/.../resourceGroups/.../providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>`). Use with `-Identity`. Mutually exclusive with `-ClientId` and `-ObjectId`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Azure Subscription Id.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TenantId
+
+Tenant ID to login to.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -UseDeviceCode
+
+Use device code flow for authentication.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Core.Abstractions.Profile
+
+The activated profile object (name, tenant ID, subscription ID, cloud, authentication method) after successful sign-in. Also persisted to the on-disk profile store; use `Get-AzProfile` later to enumerate saved profiles.
+
+## NOTES
+
+Generated help for login.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Login/Disconnect-AzAccount.md
+++ b/azps-100.0.0/Az.Login/Disconnect-AzAccount.md
@@ -1,0 +1,114 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Login.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Login
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Disconnect-AzAccount
+---
+
+# Disconnect-AzAccount
+
+## SYNOPSIS
+
+Sign out from the current Azure account context.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Disconnect-AzAccount [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Sign out from the current Azure account context.
+
+## EXAMPLES
+
+### Sign out of the current account
+
+Clears the persisted Azure account context. Subsequent Azclips cmdlets will require a fresh `Connect-AzAccount` before they can authenticate.
+
+```powershell
+Disconnect-AzAccount
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+This cmdlet does not emit an object on the pipeline; it only writes progress and status messages via the Information and Verbose streams.
+
+## NOTES
+
+Generated help for login.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Login/Get-AzProfile.md
+++ b/azps-100.0.0/Az.Login/Get-AzProfile.md
@@ -1,0 +1,132 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Login.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Login
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzProfile
+---
+
+# Get-AzProfile
+
+## SYNOPSIS
+
+Gets the saved profiles, or the active profile if -Active is specified.
+
+## SYNTAX
+
+### List (Default)
+
+```
+Get-AzProfile [<CommonParameters>]
+```
+
+### Show
+
+```
+Get-AzProfile [-Name] <string> [<CommonParameters>]
+```
+
+### ShowActive
+
+```
+Get-AzProfile -Active [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Gets the saved profiles, or the active profile if -Active is specified.
+
+## EXAMPLES
+
+### Example 1
+
+Gets the active profile.
+
+```powershell
+Get-AzProfile -Active
+```
+
+### Example 2
+
+Gets the profile named "prod".
+
+```powershell
+Get-AzProfile -Name prod
+```
+
+### Example 3
+
+Gets all saved profiles.
+
+```powershell
+Get-AzProfile
+```
+
+## PARAMETERS
+
+### -Active
+
+Gets the active profile.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: ShowActive
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+Gets the profile with the specified name.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Show
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Login.Processors.ProfileSummary
+
+One `ProfileSummary` per configured profile: name, whether it is currently active, tenant ID, subscription ID, cloud, authentication method, and user principal name.
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.Login/Remove-AzProfile.md
+++ b/azps-100.0.0/Az.Login/Remove-AzProfile.md
@@ -1,0 +1,127 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Login.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Login
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Remove-AzProfile
+---
+
+# Remove-AzProfile
+
+## SYNOPSIS
+
+Removes a saved profile by name.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Remove-AzProfile [-Name] <string> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Removes the saved profile with the specified name. If the removed profile was the active profile, the active pointer is cleared.
+
+## EXAMPLES
+
+### Example 1
+
+Removes the profile named "prod".
+
+```powershell
+Remove-AzProfile -Name prod
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+The name of the saved profile to remove.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+This cmdlet does not emit an object on the pipeline; it only writes progress and status messages via the Information and Verbose streams.
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.Login/Set-AzProfile.md
+++ b/azps-100.0.0/Az.Login/Set-AzProfile.md
@@ -1,0 +1,83 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Login.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Login
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Set-AzProfile
+---
+
+# Set-AzProfile
+
+## SYNOPSIS
+
+Sets the active profile by name.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Set-AzProfile [-Name] <string> [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Sets the specified saved profile as the active profile. The change is persisted and does not re-authenticate. Use this to switch the active tenant, subscription, etc. between profiles you have already saved.
+
+## EXAMPLES
+
+### Example 1
+
+Sets the profile named "prod" as the active profile.
+
+```powershell
+Set-AzProfile -Name prod
+```
+
+## PARAMETERS
+
+### -Name
+
+The name of the saved profile to activate.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Core.Abstractions.Profile
+
+The activated profile object with its tenant ID, subscription ID, cloud, and authentication method after the switch.
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.MsGraph/Az.MsGraph.md
+++ b/azps-100.0.0/Az.MsGraph/Az.MsGraph.md
@@ -1,0 +1,32 @@
+---
+Module Name: Az.MsGraph
+Module Guid: 2f0c9c1e-8a2d-4d5b-9f3a-7e6b1c4d8a90
+Download Help Link: https://learn.microsoft.com/powershell/module/az.msgraph
+Help Version: 0.1.0
+Locale: en-US
+content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/MsGraph/help
+original_content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/MsGraph/help
+---
+
+# Az.MsGraph Module
+## Description
+Microsoft Graph cmdlets for Azclips
+
+## Az.MsGraph Cmdlets
+### [Get-AzMsGraphApplication](Get-AzMsGraphApplication.md)
+Gets Microsoft Graph application registrations. Lists registrations in the tenant, or retrieves a single one by object ID.
+
+### [Get-AzMsGraphGroup](Get-AzMsGraphGroup.md)
+Gets Microsoft Entra groups.
+
+### [Get-AzMsGraphGroupMember](Get-AzMsGraphGroupMember.md)
+Lists the members of a Microsoft Entra group.
+
+### [Get-AzMsGraphUser](Get-AzMsGraphUser.md)
+Gets Microsoft Entra users.
+
+### [New-AzMsGraphApplication](New-AzMsGraphApplication.md)
+Creates a Microsoft Graph application registration.
+
+### [Remove-AzMsGraphApplication](Remove-AzMsGraphApplication.md)
+Deletes a Microsoft Graph application registration.

--- a/azps-100.0.0/Az.MsGraph/Get-AzMsGraphApplication.md
+++ b/azps-100.0.0/Az.MsGraph/Get-AzMsGraphApplication.md
@@ -1,0 +1,239 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.MsGraph.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.MsGraph
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzMsGraphApplication
+---
+
+# Get-AzMsGraphApplication
+
+## SYNOPSIS
+
+Gets Microsoft Graph application registrations. Lists registrations in the tenant, or retrieves a single one by object ID.
+
+## SYNTAX
+
+### List (Default)
+
+```
+Get-AzMsGraphApplication [-Filter <string>] [-Orderby <string[]>] [-Search <string>]
+ [-ConsistencyLevel <string>] [-Select <string[]>] [<CommonParameters>]
+```
+
+### DisplayName
+
+```
+Get-AzMsGraphApplication -DisplayName <string> [-Select <string[]>] [<CommonParameters>]
+```
+
+### Get
+
+```
+Get-AzMsGraphApplication -Id <string> [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Queries Microsoft Graph for application registrations using the active Azure profile (see `Connect-AzAccount`). The available parameter sets are:
+
+- **List (Default)**: returns the first page of applications. Combine with `-Filter`, `-Orderby`, `-Search`, and `-ConsistencyLevel` for raw OData queries. Pagination is not followed in this preview.
+- **DisplayName**: shortcut that translates to the OData filter `displayName eq '<value>'`.
+- **Get**: retrieves a single application by object ID.
+
+`-Select` controls OData projection and is available in the list-based parameter sets.
+
+## EXAMPLES
+
+### Example 1: List the first page of applications
+
+```powershell
+Get-AzMsGraphApplication
+```
+
+### Example 2: List applications by exact display name
+
+```powershell
+Get-AzMsGraphApplication -DisplayName my-app
+```
+
+### Example 3: Get an application by object ID
+
+```powershell
+Get-AzMsGraphApplication -Id 00000000-0000-0000-0000-000000000000
+```
+
+## PARAMETERS
+
+### -ConsistencyLevel
+
+Set to `eventual` to enable advanced query features such as `$search`, `$count`, or `$orderby` on non-indexed properties.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DisplayName
+
+Exact display name to match. Translated to the OData filter `displayName eq '<value>'`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: DisplayName
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Filter
+
+OData `$filter` expression applied by Microsoft Graph. Passed through verbatim.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Id
+
+The object ID of the application registration to retrieve.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Orderby
+
+OData `$orderby` values, for example `displayName` or `createdDateTime desc`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Search
+
+OData `$search` expression, for example `"displayName:contoso"`. Requires `-ConsistencyLevel eventual`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Select
+
+Properties to project via OData `$select`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.MsGraph.Models.Application
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.MsGraph/Get-AzMsGraphGroup.md
+++ b/azps-100.0.0/Az.MsGraph/Get-AzMsGraphGroup.md
@@ -1,0 +1,386 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.MsGraph.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.MsGraph
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzMsGraphGroup
+---
+
+# Get-AzMsGraphGroup
+
+## SYNOPSIS
+
+Gets Microsoft Entra groups.
+
+## SYNTAX
+
+### List (Default)
+
+```
+Get-AzMsGraphGroup [-Filter <string>] [-Orderby <string[]>] [-Search <string>]
+ [-ConsistencyLevel <string>] [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### DisplayName
+
+```
+Get-AzMsGraphGroup -DisplayName <string> [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### StartsWith
+
+```
+Get-AzMsGraphGroup -DisplayNameStartsWith <string> [-Select <string[]>] [-Expand <string[]>]
+ [-AppendSelected] [<CommonParameters>]
+```
+
+### Get
+
+```
+Get-AzMsGraphGroup -ObjectId <string> [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### DisplayNameStartsWith
+
+```
+Get-AzMsGraphGroup -DisplayNameStartsWith <string> [-Select <string[]>] [-Expand <string[]>]
+ [-AppendSelected] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Look up Microsoft Entra groups in your tenant. Without parameters, lists groups in the signed-in tenant. Use `-ObjectId` to retrieve a single group by object ID; `-DisplayName` or `-DisplayNameStartsWith` to match by display name; or `-Filter`, `-Orderby`, `-Search` for custom queries.
+
+## EXAMPLES
+
+### Example 1: List all groups
+
+```powershell
+Get-AzMsGraphGroup
+```
+
+### Example 2: List groups with the specified display name
+
+```powershell
+Get-AzMsGraphGroup -DisplayName 'Sales Team'
+```
+
+### Example 3: List groups whose display name starts with a prefix
+
+```powershell
+Get-AzMsGraphGroup -DisplayNameStartsWith Sales
+```
+
+### Example 4: List groups with a custom filter expression
+
+```powershell
+Get-AzMsGraphGroup -Filter "securityEnabled eq true"
+```
+
+### Example 5: Get a group by object ID
+
+```powershell
+Get-AzMsGraphGroup -ObjectId 11111111-2222-3333-4444-555555555555
+```
+
+### Example 6: Return a subset of properties, widened with the defaults
+
+```powershell
+Get-AzMsGraphGroup -Select 'visibility','createdDateTime' -AppendSelected
+```
+
+## PARAMETERS
+
+### -AppendSelected
+
+When set with `-Select`, include the default property set (`displayName`, `id`, `deletedDateTime`, `securityEnabled`, `mailEnabled`, `mailNickname`, `description`) alongside the values in `-Select` rather than replacing them.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayNameStartsWith
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ConsistencyLevel
+
+Set to `eventual` to enable advanced query features such as `$search`, `$count`, or `$orderby` on non-indexed properties.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DisplayName
+
+List groups with the specified display name.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: DisplayName
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DisplayNameStartsWith
+
+List groups whose display name starts with the specified prefix.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- SearchString
+ParameterSets:
+- Name: DisplayNameStartsWith
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Expand
+
+Related properties to include in the response, for example `members`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayNameStartsWith
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Filter
+
+OData `$filter` expression, for example `"securityEnabled eq true"`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ObjectId
+
+The object ID of the group.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- Id
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Orderby
+
+OData `$orderby` values, for example `'displayName'` or `'createdDateTime desc'`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Search
+
+OData `$search` expression, for example `"displayName:contoso"`. Requires `-ConsistencyLevel eventual`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Select
+
+Properties to return. Combine with `-AppendSelected` to include the default properties as well.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayNameStartsWith
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Object
+
+The Microsoft Entra group object or objects returned by the query.
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.MsGraph/Get-AzMsGraphGroupMember.md
+++ b/azps-100.0.0/Az.MsGraph/Get-AzMsGraphGroupMember.md
@@ -1,0 +1,252 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.MsGraph.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.MsGraph
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzMsGraphGroupMember
+---
+
+# Get-AzMsGraphGroupMember
+
+## SYNOPSIS
+
+Lists the members of a Microsoft Entra group.
+
+## SYNTAX
+
+### ObjectId (Default)
+
+```
+Get-AzMsGraphGroupMember -GroupObjectId <string> [-Filter <string>] [-Select <string[]>]
+ [-Expand <string[]>] [-Orderby <string[]>] [-Search <string>] [-ConsistencyLevel <string>]
+ [<CommonParameters>]
+```
+
+### DisplayName
+
+```
+Get-AzMsGraphGroupMember -GroupDisplayName <string> [-Filter <string>] [-Select <string[]>]
+ [-Expand <string[]>] [-Orderby <string[]>] [-Search <string>] [-ConsistencyLevel <string>]
+ [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+List every user, group, service principal, or device that is a direct member of the specified group. Identify the target group by object ID (`-GroupObjectId`) or by exact display name (`-GroupDisplayName`). Use `-Filter`, `-Search`, and `-Orderby` for custom queries on the returned members.
+
+## EXAMPLES
+
+### Example 1: List members by group object ID
+
+```powershell
+Get-AzMsGraphGroupMember -GroupObjectId 11111111-2222-3333-4444-555555555555
+```
+
+### Example 2: List members by group display name
+
+```powershell
+Get-AzMsGraphGroupMember -GroupDisplayName 'Sales Team'
+```
+
+### Example 3: List members whose display name starts with a prefix
+
+```powershell
+Get-AzMsGraphGroupMember -GroupObjectId 11111111-2222-3333-4444-555555555555 -Filter "startswith(displayName,'Ada')"
+```
+
+## PARAMETERS
+
+### -ConsistencyLevel
+
+Set to `eventual` to enable advanced query features such as `$search`, `$count`, or `$orderby` on non-indexed properties.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Expand
+
+Related properties to include in the response.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Filter
+
+OData `$filter` expression.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -GroupDisplayName
+
+The exact display name of the target group.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: DisplayName
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -GroupObjectId
+
+The object ID of the group.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- Id
+- ObjectId
+ParameterSets:
+- Name: ObjectId
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Orderby
+
+OData `$orderby` values.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Search
+
+OData `$search` expression. Requires `-ConsistencyLevel eventual`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Select
+
+Properties to return.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Object
+
+The directory objects (users, groups, service principals, or devices) that are members of the group.
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.MsGraph/Get-AzMsGraphUser.md
+++ b/azps-100.0.0/Az.MsGraph/Get-AzMsGraphUser.md
@@ -1,0 +1,481 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.MsGraph.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.MsGraph
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzMsGraphUser
+---
+
+# Get-AzMsGraphUser
+
+## SYNOPSIS
+
+Gets Microsoft Entra users.
+
+## SYNTAX
+
+### List (Default)
+
+```
+Get-AzMsGraphUser [-Filter <string>] [-Orderby <string[]>] [-Search <string>]
+ [-ConsistencyLevel <string>] [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### Mail
+
+```
+Get-AzMsGraphUser -Mail <string> [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### DisplayName
+
+```
+Get-AzMsGraphUser -DisplayName <string> [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### StartsWith
+
+```
+Get-AzMsGraphUser -StartsWith <string> [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### Get
+
+```
+Get-AzMsGraphUser -Id <string> [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+### SignedIn
+
+```
+Get-AzMsGraphUser -SignedIn [-Select <string[]>] [-Expand <string[]>] [-AppendSelected]
+ [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Look up Microsoft Entra users in your tenant. Without parameters, lists users in the signed-in tenant. Use `-Id` to retrieve a single user by object ID or user principal name; `-SignedIn` for the currently signed-in user; `-Mail`, `-DisplayName`, or `-StartsWith` to match by that property; or `-Filter`, `-Orderby`, `-Search` for custom queries.
+
+## EXAMPLES
+
+### Example 1: List all users
+
+```powershell
+Get-AzMsGraphUser
+```
+
+### Example 2: List users with the specified mail address
+
+```powershell
+Get-AzMsGraphUser -Mail ada@contoso.com
+```
+
+### Example 3: List users with the specified display name
+
+```powershell
+Get-AzMsGraphUser -DisplayName 'Ada Lovelace'
+```
+
+### Example 4: List users whose display name starts with a prefix
+
+```powershell
+Get-AzMsGraphUser -StartsWith Ada
+```
+
+### Example 5: List users with a custom filter expression
+
+```powershell
+Get-AzMsGraphUser -Filter "endswith(mail,'@contoso.com')" -ConsistencyLevel eventual
+```
+
+### Example 6: Get a user by object ID or user principal name
+
+```powershell
+Get-AzMsGraphUser -Id 00000000-0000-0000-0000-000000000000
+```
+
+### Example 7: Get the currently signed-in user
+
+```powershell
+Get-AzMsGraphUser -SignedIn
+```
+
+### Example 8: Return a subset of properties, widened with the defaults
+
+```powershell
+Get-AzMsGraphUser -Select 'city','department' -AppendSelected
+```
+
+## PARAMETERS
+
+### -AppendSelected
+
+When set with `-Select`, include the default property set (`displayName`, `id`, `deletedDateTime`, `userPrincipalName`, `usageLocation`, `givenName`, `surname`, `accountEnabled`, `mailNickname`, `mail`) alongside the values in `-Select` rather than replacing them.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Mail
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: StartsWith
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: SignedIn
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ConsistencyLevel
+
+Set to `eventual` to enable advanced query features such as `$search`, `$count`, or `$orderby` on non-indexed properties.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -DisplayName
+
+List users with the specified display name.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: DisplayName
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Expand
+
+Related properties to include in the response, for example `memberOf`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Mail
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: StartsWith
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: SignedIn
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Filter
+
+OData `$filter` expression, for example `"accountEnabled eq true"`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Id
+
+The object ID or user principal name (UPN) of the user to retrieve.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Mail
+
+List users with the specified mail address.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Mail
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Orderby
+
+OData `$orderby` values, for example `'displayName'` or `'mail desc'`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Search
+
+OData `$search` expression, for example `"displayName:ada"`. Requires `-ConsistencyLevel eventual`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Select
+
+Properties to return. Combine with `-AppendSelected` to include the default properties as well.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Mail
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: DisplayName
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: StartsWith
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: SignedIn
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SignedIn
+
+Return the currently signed-in user.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: SignedIn
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -StartsWith
+
+List users whose display name starts with the specified prefix.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: StartsWith
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Object
+
+The Microsoft Entra user object or objects returned by the query.
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.MsGraph/New-AzMsGraphApplication.md
+++ b/azps-100.0.0/Az.MsGraph/New-AzMsGraphApplication.md
@@ -1,0 +1,103 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.MsGraph.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.MsGraph
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: New-AzMsGraphApplication
+---
+
+# New-AzMsGraphApplication
+
+## SYNOPSIS
+
+Creates a Microsoft Graph application registration.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-AzMsGraphApplication -DisplayName <string> [-SignInAudience <string>] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Creates a new application registration in Microsoft Graph using the active Azure profile (see `Connect-AzAccount`). Only a display name is required; the created application, including its generated object ID and app ID, is returned.
+
+## EXAMPLES
+
+### Example 1: Create an application registration
+
+```powershell
+New-AzMsGraphApplication -DisplayName my-app
+```
+
+### Example 2: Create an application for a single-tenant audience
+
+```powershell
+New-AzMsGraphApplication -DisplayName my-app -SignInAudience AzureADMyOrg
+```
+
+## PARAMETERS
+
+### -DisplayName
+
+The display name of the application registration.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SignInAudience
+
+The Microsoft account types supported for sign-in, for example AzureADMyOrg, AzureADMultipleOrgs, or AzureADandPersonalMicrosoftAccount.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.MsGraph.Models.Application
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.MsGraph/Remove-AzMsGraphApplication.md
+++ b/azps-100.0.0/Az.MsGraph/Remove-AzMsGraphApplication.md
@@ -1,0 +1,120 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.MsGraph.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.MsGraph
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Remove-AzMsGraphApplication
+---
+
+# Remove-AzMsGraphApplication
+
+## SYNOPSIS
+
+Deletes a Microsoft Graph application registration.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Remove-AzMsGraphApplication -Id <string> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Deletes an application registration from Microsoft Graph using the active Azure profile (see `Connect-AzAccount`). The identifier is the application's object ID. Graph performs a soft delete; the application is recoverable for 30 days.
+
+## EXAMPLES
+
+### Example 1: Delete an application by object ID
+
+```powershell
+Remove-AzMsGraphApplication -Id 00000000-0000-0000-0000-000000000000
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Id
+
+The object ID of the application registration to delete.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Void
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+

--- a/azps-100.0.0/Az.Resources/Az.Resources.md
+++ b/azps-100.0.0/Az.Resources/Az.Resources.md
@@ -1,0 +1,29 @@
+---
+Module Name: Az.Resources
+Module Guid: d4bb27e5-ae5f-4f79-a25c-ad1cecdc443a
+Download Help Link: https://learn.microsoft.com/powershell/module/az.resources
+Help Version: 0.1.0
+Locale: en-US
+content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Resources/help
+original_content_git_url: https://github.com/Azure/azclips/tree/main/src/PS/Resources/help
+---
+
+# Az.Resources Module
+## Description
+Azure PowerShell - Resources
+
+## Az.Resources Cmdlets
+### [Get-AzResourceGroup](Get-AzResourceGroup.md)
+Show details of a specific resource group.
+
+### [Invoke-AzRestMethod](Invoke-AzRestMethod.md)
+Send an authenticated REST request to Azure Resource Manager and return the raw response.
+
+### [New-AzResourceGroup](New-AzResourceGroup.md)
+Create a new resource group.
+
+### [New-AzResourceGroupDeployment](New-AzResourceGroupDeployment.md)
+Deploy an ARM or Bicep template into an existing resource group.
+
+### [New-AzResourceGroupDeploymentWhatIf](New-AzResourceGroupDeploymentWhatIf.md)
+Preview the changes an ARM or Bicep deployment would make to a resource group without applying them.

--- a/azps-100.0.0/Az.Resources/Get-AzResourceGroup.md
+++ b/azps-100.0.0/Az.Resources/Get-AzResourceGroup.md
@@ -1,0 +1,151 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Resources.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Resources
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Get-AzResourceGroup
+---
+
+# Get-AzResourceGroup
+
+## SYNOPSIS
+
+Show details of a specific resource group.
+
+## SYNTAX
+
+### List (Default)
+
+```
+Get-AzResourceGroup [-SubscriptionId <string>] [-Profile <string>] [<CommonParameters>]
+```
+
+### Get
+
+```
+Get-AzResourceGroup -Name <string> [-SubscriptionId <string>] [-Profile <string>]
+ [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Display information about a resource group including its name, location, provisioning state, and resource count.
+Specify the resource group name and optionally the subscription ID (defaults to current subscription if not provided).
+
+## EXAMPLES
+
+### Show a resource group
+
+Return the properties of the resource group `myrg` in the specified subscription.
+
+```powershell
+Get-AzResourceGroup -SubscriptionId 00000000-0000-0000-0000-000000000000 -Name myrg
+```
+
+### List all resource groups in a subscription
+
+List every resource group in the specified subscription. Omit `-Name` to list rather than fetch.
+
+```powershell
+Get-AzResourceGroup -SubscriptionId 00000000-0000-0000-0000-000000000000
+```
+
+## PARAMETERS
+
+### -Name
+
+The name of the resource group.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of a saved profile to use for this call instead of the currently-active one. Manage profiles with `Set-AzProfile` / `Get-AzProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Azure Subscription Id. Defaults to the active profile's subscription.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: Get
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: List
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Resources.Models.ResourceGroup
+
+One `ResourceGroup` object per matching group — a single result when `-Name` is supplied (Get mode), an array of results otherwise (List mode). Includes the name, location, provisioning state, and tags.
+
+## NOTES
+
+Generated help for resources.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Resources/Invoke-AzRestMethod.md
+++ b/azps-100.0.0/Az.Resources/Invoke-AzRestMethod.md
@@ -1,0 +1,321 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Resources.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Resources
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-AzRestMethod
+---
+
+# Invoke-AzRestMethod
+
+## SYNOPSIS
+
+Send an authenticated REST request to Azure Resource Manager and return the raw response.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Invoke-AzRestMethod [-Method <string>] [-Uri <string>] [-Payload <string>] [-Headers <Object>]
+ [-SubscriptionId <string>] [-ResourceGroupName <string>] [-ResourceProviderName <string>]
+ [-ResourceType <string[]>] [-Name <string[]>] [-ApiVersion <string>] [-UriParameters <Object>]
+ [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+`Invoke-AzRestMethod` is a universal authenticated ARM REST passthrough, mirroring `az rest` and `Invoke-AzRestMethod`. It sends an arbitrary HTTP request through the already-authenticated AzClips pipeline to Azure Resource Manager and returns the raw response: the HTTP status code, the response headers, and the response body. When the response body is JSON, a parsed `Json` representation is also returned alongside the raw content.
+
+The target URL can be supplied two ways. In **Uri mode**, pass `-Uri` with an absolute ARM URL or a relative ARM path (relative paths are prefixed with `https://management.azure.com`, and the token `{subscriptionId}` is replaced with the current subscription). In **ByParameters mode**, build the URL piece-wise from `-SubscriptionId`, `-ResourceGroupName`, `-ResourceProviderName`, `-ResourceType`, `-Name`, and `-ApiVersion`. The two modes are mutually exclusive.
+
+This cmdlet performs no long-running-operation polling and no automatic pagination, and it targets the Azure Resource Manager audience only. Use it to call ARM endpoints that do not yet have a dedicated cmdlet.
+
+## EXAMPLES
+
+### Example 1: List resource groups in a subscription (Uri mode)
+
+Send a `GET` to an absolute ARM path and read the parsed JSON from the response.
+
+```powershell
+Invoke-AzRestMethod -Method GET -Uri "/subscriptions/{subscriptionId}/resourcegroups?api-version=2021-04-01"
+```
+
+### Example 2: Get a resource group built from parameters (ByParameters mode)
+
+Build the ARM URL piece-wise instead of passing a full URI. The default method is `GET`.
+
+```powershell
+Invoke-AzRestMethod -ResourceGroupName myRg -ApiVersion 2021-04-01
+```
+
+### Example 3: Create or update a resource group with a JSON payload
+
+Send a `PUT` with a request body and a custom header.
+
+```powershell
+Invoke-AzRestMethod -Method PUT -Uri "/subscriptions/{subscriptionId}/resourcegroups/myRg?api-version=2021-04-01" -Payload '{"location":"eastus"}' -Headers @{ 'Content-Type' = 'application/json' }
+```
+
+## PARAMETERS
+
+### -ApiVersion
+
+The `api-version` used when building an ARM URL from piece-wise parameters. Required in ByParameters mode. Mutually exclusive with `-Uri`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Headers
+
+Optional request headers, supplied either as a hashtable (`@{ 'Accept' = 'application/json' }`) or as a string array in `KEY=VALUE` form (`'Accept=application/json'`).
+
+```yaml
+Type: System.Object
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Method
+
+The HTTP method to use (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, or `OPTIONS`). Defaults to `GET`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+Resource name segments, interleaved with `-ResourceType` (may have one fewer entry than `-ResourceType` for a collection GET). Used to build an ARM URL from piece-wise parameters. Mutually exclusive with `-Uri`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Payload
+
+Optional request body (typically JSON). Sent whenever provided, for any HTTP method.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceGroupName
+
+Resource group name segment used to build an ARM URL from piece-wise parameters. Mutually exclusive with `-Uri`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceProviderName
+
+Resource provider namespace (for example, `Microsoft.Resources`) used to build an ARM URL from piece-wise parameters. Mutually exclusive with `-Uri`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceType
+
+Resource type segments, interleaved with `-Name`, used to build an ARM URL from piece-wise parameters. Mutually exclusive with `-Uri`.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Subscription id used to build an ARM URL from piece-wise parameters. Defaults to the current subscription. Mutually exclusive with `-Uri`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Uri
+
+Absolute URL or relative ARM path for the request. Relative paths are prefixed with `https://management.azure.com`, and the token `{subscriptionId}` is replaced with the current subscription. Mutually exclusive with the piece-wise ByParameters inputs (`-SubscriptionId`, `-ResourceGroupName`, `-ResourceProviderName`, `-ResourceType`, `-Name`, `-ApiVersion`).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -UriParameters
+
+Optional query-string parameters, supplied either as a hashtable (`@{ '$top' = '3' }`) or as a string array in `KEY=VALUE` form (`'$top=3'`). Appended to the final URL in either mode.
+
+```yaml
+Type: System.Object
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Resources.Models.RestResponse
+
+A `RestResponse` object containing the HTTP status code, response headers, parsed JSON body (when applicable), and raw body text.
+
+## NOTES
+
+This cmdlet targets the Azure Resource Manager audience only. It does not poll long-running operations and does not page through `nextLink` results; for paged endpoints, follow the returned `nextLink` yourself with another call.
+
+## RELATED LINKS
+
+
+- [Get-AzResourceGroup]()
+- [New-AzResourceGroupDeployment]()

--- a/azps-100.0.0/Az.Resources/New-AzResourceGroup.md
+++ b/azps-100.0.0/Az.Resources/New-AzResourceGroup.md
@@ -1,0 +1,210 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Resources.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Resources
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: New-AzResourceGroup
+---
+
+# New-AzResourceGroup
+
+## SYNOPSIS
+
+Create a new resource group.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-AzResourceGroup -Name <string> -Location <string> [-SubscriptionId <string>] [-Profile <string>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Provision a new resource group in your Azure subscription.
+Specify the resource group name and location (region).
+The subscription ID is optional and defaults to the current subscription when omitted.
+The resource group will be created immediately and can be used to organize your Azure resources.
+
+## EXAMPLES
+
+### Create a resource group in the current subscription
+
+Provision a new resource group named `myrg` in the East US region using the current subscription.
+
+```powershell
+New-AzResourceGroup -Name myrg -Location eastus
+```
+
+### Create a resource group in a specific subscription
+
+Provision a new resource group named `myrg` in the East US region under a specific subscription.
+
+```powershell
+New-AzResourceGroup -Name myrg -Location eastus -SubscriptionId 00000000-0000-0000-0000-000000000000
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Location
+
+Location for resource group.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+The name of the resource group.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of a saved profile to use for this call instead of the currently-active one. Manage profiles with `Set-AzProfile` / `Get-AzProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+Azure Subscription Id. Defaults to the active profile's subscription.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Resources.Models.ResourceGroup
+
+The newly-created `ResourceGroup` object, including its ARM resource ID and provisioning state.
+
+## NOTES
+
+Generated help for resources.
+
+## RELATED LINKS
+
+
+- [Online Version]()

--- a/azps-100.0.0/Az.Resources/New-AzResourceGroupDeployment.md
+++ b/azps-100.0.0/Az.Resources/New-AzResourceGroupDeployment.md
@@ -1,0 +1,431 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Resources.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Resources
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: New-AzResourceGroupDeployment
+---
+
+# New-AzResourceGroupDeployment
+
+## SYNOPSIS
+
+Deploy an ARM or Bicep template into an existing resource group.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-AzResourceGroupDeployment -ResourceGroupName <string> -Name <string> [-TemplateUri <string>]
+ [-TemplateFile <string>] [-TemplateSpecId <string>] [-QueryString <string>]
+ [-ParametersUri <string>] [-ParametersFile <string>] [-Mode <string>] [-Parameter <string[]>]
+ [-RollbackOnError] [-RollbackToDeploymentName <string>] [-ValidationLevel <string>]
+ [-SubscriptionId <string>] [-Profile <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Submits a deployment to the specified resource group using an ARM/Bicep template supplied either inline (`-TemplateFile`), via URL (`-TemplateUri`), or by referencing a template spec (`-TemplateSpecId`). Template parameters can be supplied via file, URI, query string, or as `Name=Value` pairs through `-Parameter`.
+Use `-Mode Complete` for full reconciliation, or `-Mode Incremental` (default) to add and update without removing untracked resources.
+
+## EXAMPLES
+
+### Deploy a Bicep file into an existing resource group
+
+Submit `main.bicep` along with parameter file `main.parameters.json` as deployment `infra-prod-2026-06-16` into resource group `myrg`.
+
+```powershell
+New-AzResourceGroupDeployment -ResourceGroupName myrg -Name infra-prod-2026-06-16 -TemplateFile ./main.bicep -ParametersFile ./main.parameters.json -Mode Incremental
+```
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Mode
+
+Deployment mode. Use `Incremental` (default) to add and update resources, or `Complete` to delete resources in the resource group that aren't declared in the template.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+The name of the deployment. Used to track and reference the deployment in deployment history.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Parameter
+
+Template parameters supplied as inline `Name=Value` pairs. Use this when you don't have a parameters file. Repeat the flag or pass an array for multiple values.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ParametersFile
+
+Path to a local ARM/Bicep parameters file (`*.parameters.json`).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ParametersUri
+
+URI of a remote ARM/Bicep parameters file (for example, a blob URL).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Profile
+
+Name of a saved profile to use for this call instead of the currently-active one. Manage profiles with `Set-AzProfile` / `Get-AzProfile`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -QueryString
+
+Optional SAS or query string appended to `-TemplateUri` / `-ParametersUri` when those URIs require authentication.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceGroupName
+
+The name of the resource group that will receive the deployment. The resource group must already exist.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RollbackOnError
+
+If the deployment fails, automatically roll back to the last successful deployment in this resource group.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -RollbackToDeploymentName
+
+Name of an explicit prior deployment to roll back to on failure. Implies the rollback behaviour of `-RollbackOnError`.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+The Azure subscription ID that owns the target resource group. Defaults to the active profile's subscription when omitted.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TemplateFile
+
+Path to a local ARM JSON or Bicep template file.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TemplateSpecId
+
+Resource ID of an existing template spec to deploy (for example, `/subscriptions/.../providers/Microsoft.Resources/templateSpecs/<spec>/versions/<version>`).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TemplateUri
+
+URI of a remote ARM/Bicep template (for example, a blob URL).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ValidationLevel
+
+Deployment validation strictness. Common values are `Provider` (default) and `Template`. Use a stricter level to catch schema or parameter issues earlier.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Resources.Models.DeploymentExtended
+
+The completed `DeploymentExtended` object containing the deployment name, provisioning state, outputs declared by the template, and correlation ID.
+
+## NOTES
+
+The target resource group must already exist. Use `New-AzResourceGroup` to create it first when bootstrapping a new environment.
+
+## RELATED LINKS
+
+
+- [New-AzResourceGroup]()
+- [Get-AzResourceGroup]()

--- a/azps-100.0.0/Az.Resources/New-AzResourceGroupDeploymentWhatIf.md
+++ b/azps-100.0.0/Az.Resources/New-AzResourceGroupDeploymentWhatIf.md
@@ -1,0 +1,348 @@
+---
+document type: cmdlet
+external help file: Microsoft.Azure.Azclips.Cmdlets.Resources.dll-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Az.Resources
+ms.date: 09/01/2026
+PlatyPS schema version: 2024-05-01
+title: New-AzResourceGroupDeploymentWhatIf
+---
+
+# New-AzResourceGroupDeploymentWhatIf
+
+## SYNOPSIS
+
+Preview the changes an ARM or Bicep deployment would make to a resource group without applying them.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+New-AzResourceGroupDeploymentWhatIf -ResourceGroupName <string> -Name <string>
+ [-TemplateUri <string>] [-TemplateFile <string>] [-TemplateSpecId <string>] [-QueryString <string>]
+ [-ParametersUri <string>] [-ParametersFile <string>] [-Mode <string>] [-Parameter <string[]>]
+ [-ValidationLevel <string>] [-ResultFormat <string>] [-SubscriptionId <string>]
+ [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+Runs an ARM/Bicep what-if operation against an existing resource group and returns the set of resource changes the deployment would produce — additions, modifications, deletions, and no-ops — without creating or modifying any resources. The template is supplied either inline (`-TemplateFile`), via URL (`-TemplateUri`), or by referencing a template spec (`-TemplateSpecId`). Template parameters can be supplied via file, URI, query string, or as `Name=Value` pairs through `-Parameter`.
+Use `-ResultFormat ResourceIdOnly` for a compact summary, or `-ResultFormat FullResourcePayloads` (default) to include the full predicted resource bodies.
+
+## EXAMPLES
+
+### Preview a Bicep deployment before applying it
+
+Run a what-if for `main.bicep` with parameter file `main.parameters.json` as deployment `infra-prod-2026-06-18` against resource group `myrg`.
+
+```powershell
+New-AzResourceGroupDeploymentWhatIf -ResourceGroupName myrg -Name infra-prod-2026-06-18 -TemplateFile ./main.bicep -ParametersFile ./main.parameters.json -Mode Incremental
+```
+
+## PARAMETERS
+
+### -Mode
+
+Deployment mode used to evaluate the change set. Use `Incremental` (default) to add and update resources, or `Complete` to also report resources in the resource group that aren't declared in the template.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Name
+
+The name of the deployment. Used to track and reference the what-if operation in deployment history.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Parameter
+
+Template parameters supplied as inline `Name=Value` pairs. Use this when you don't have a parameters file. Repeat the flag or pass an array for multiple values.
+
+```yaml
+Type: System.String[]
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ParametersFile
+
+Path to a local ARM/Bicep parameters file (`*.parameters.json`).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ParametersUri
+
+URI of a remote ARM/Bicep parameters file (for example, a blob URL).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -QueryString
+
+Optional SAS or query string appended to `-TemplateUri` / `-ParametersUri` when those URIs require authentication.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResourceGroupName
+
+The name of the resource group to run the what-if against. The resource group must already exist.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ResultFormat
+
+The format of the what-if results. Use `FullResourcePayloads` (default) to include the full predicted resource bodies, or `ResourceIdOnly` for a compact list of affected resource IDs.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues:
+- FullResourcePayloads
+- ResourceIdOnly
+HelpMessage: ''
+```
+
+### -SubscriptionId
+
+The Azure subscription ID that owns the target resource group. Defaults to the active profile's subscription when omitted.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TemplateFile
+
+Path to a local ARM JSON or Bicep template file.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TemplateSpecId
+
+Resource ID of an existing template spec to evaluate (for example, `/subscriptions/.../providers/Microsoft.Resources/templateSpecs/<spec>/versions/<version>`).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TemplateUri
+
+URI of a remote ARM/Bicep template (for example, a blob URL).
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ValidationLevel
+
+What-if validation strictness. Common values are `Provider` (default) and `Template`. Use a stricter level to catch schema or parameter issues earlier.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### Microsoft.Azure.Azclips.Extensions.Resources.Models.WhatIfOperationResult
+
+A `WhatIfOperationResult` describing the changes the deployment would apply if executed. No resources are created or modified; the caller can inspect the change list before running the real deployment.
+
+## NOTES
+
+What-if is a read-only preview: it never creates or modifies resources. Use `New-AzResourceGroupDeployment` to apply the changes once the preview looks correct.
+
+## RELATED LINKS
+
+
+- [New-AzResourceGroupDeployment]()
+- [New-AzResourceGroup]()
+- [Get-AzResourceGroup]()

--- a/docfx.json
+++ b/docfx.json
@@ -1,6 +1,10 @@
 {
     "build": {
         "content": [
+            { "files": ["toc.yml"], "src": "azps-100.0.0", "version": "azps-100.0.0", "dest": "module/azure-powershell" },
+            { "files": ["**/*.yml"], "src": "azps-100.0.0", "version": "azps-100.0.0", "exclude": ["docs-conceptual/**"], "dest": "module" },
+            { "files": ["**/*.yml", "**/*.md"], "src": "docs-conceptual/azps-100.0.0", "version": "azps-100.0.0", "dest": "azure" },
+
             { "files": ["toc.yml"], "src": "azps-16.3.0", "version": "azps-16.3.0", "dest": "module/azure-powershell" },
             { "files": ["**/*.yml"], "src": "azps-16.3.0", "version": "azps-16.3.0", "exclude": ["docs-conceptual/**"], "dest": "module" },
             { "files": ["**/*.yml", "**/*.md"], "src": "docs-conceptual/azps-16.3.0", "version": "azps-16.3.0", "dest": "azure" },
@@ -24,11 +28,13 @@
             }
         ],
         "resource": [
+            { "files": ["media/**"], "version": "azps-100.0.0" },
             { "files": ["media/**"], "version": "azps-16.3.0" },
             { "files": ["media/**"], "version": "azps-15.6.0" },
             { "files": ["media/**"], "version": "azps-0.10.0" }
         ],
         "versions": {
+            "azps-100.0.0": { "dest": "azps-100.0.0" },
             "azps-16.3.0": { "dest": "azps-16.3.0" },
             "azps-15.6.0": { "dest": "azps-15.6.0" },
             "azps-0.10.0": { "dest": "azps-0.10.0" }
@@ -388,6 +394,7 @@
                 "docs-conceptual/**/*": "concept-article"
             },
             "ms.date": {
+                "azps-100.0.0/**/*": "9/07/2026",
                 "azps-16.3.0/**/*": "9/01/2026",
                 "azps-15.6.0/**/*": "5/05/2026",
                 "azps-0.10.0/**/*": "4/14/2020"
@@ -410,6 +417,8 @@
             "ROBOTS": {
             },
             "feedback_system": {
+                "azps-100.0.0/**/*": "OpenSource",
+                "docs-conceptual/azps-100.0.0/*": "OpenSource",
                 "azps-16.3.0/**/*": "OpenSource",
                 "docs-conceptual/azps-16.3.0/*": "OpenSource",
                 "azps-15.6.0/**/*": "None",

--- a/docs-conceptual/azps-100.0.0/toc.yml
+++ b/docs-conceptual/azps-100.0.0/toc.yml
@@ -1,0 +1,5 @@
+items:
+  - name: AzClips PowerShell (Preview)
+    items:
+      - name: Overview
+        href: index.yml

--- a/mapping/az-groupMapping-100.0.0.json
+++ b/mapping/az-groupMapping-100.0.0.json
@@ -1,0 +1,30 @@
+{
+  "Get-AzVM": "Compute",
+  "New-AzVM": "Compute",
+  "Remove-AzVM": "Compute",
+
+  "Get-AzConfig": "Config",
+  "Get-AzConfigInfo": "Config",
+  "Get-AzConfigList": "Config",
+  "Remove-AzConfig": "Config",
+  "Set-AzConfig": "Config",
+
+  "Connect-AzAccount": "Accounts",
+  "Disconnect-AzAccount": "Accounts",
+  "Get-AzProfile": "Accounts",
+  "Remove-AzProfile": "Accounts",
+  "Set-AzProfile": "Accounts",
+
+  "Get-AzMsGraphApplication": "MS Graph",
+  "Get-AzMsGraphGroup": "MS Graph",
+  "Get-AzMsGraphGroupMember": "MS Graph",
+  "Get-AzMsGraphUser": "MS Graph",
+  "New-AzMsGraphApplication": "MS Graph",
+  "Remove-AzMsGraphApplication": "MS Graph",
+
+  "Get-AzResourceGroup": "Resources",
+  "Invoke-AzRestMethod": "Resources",
+  "New-AzResourceGroup": "Resources",
+  "New-AzResourceGroupDeployment": "Resources",
+  "New-AzResourceGroupDeploymentWhatIf": "Resources"
+}

--- a/mapping/monikerMapping.json
+++ b/mapping/monikerMapping.json
@@ -1,4 +1,11 @@
 {
+    "azps-100.0.0": {
+        "conceptualToc": "docs-conceptual/azps-100.0.0/toc.yml",
+        "conceptualTocUrl": "/powershell/azure/toc.json",
+        "packageRoot": "azps-100.0.0",
+        "referenceTocUrl": "/powershell/module/azure-powershell/toc.json",
+        "serviceMap": "mapping/az-groupMapping-100.0.0.json"
+    },
     "azps-16.3.0": {
         "conceptualToc": "docs-conceptual/azps-16.3.0/toc.yml",
         "conceptualTocUrl": "/powershell/azure/toc.json",


### PR DESCRIPTION
Onboards the AzClips PowerShell public preview under the `azps-100.0.0` moniker (friendly name: **Az PowerShell 0.10.0 Preview**). Version `100.0.0` sorts above every real Az PS release on the dropdown; the "Preview" label distinguishes it.

## Two commits

1. **`c2dd189a9`** — moniker registration (config-only, hand-authored)
2. **`456348b6f`** — first content drop (script-driven, see below)

### 1. Registration commit — `c2dd189a9`

| File | Change |
|------|--------|
| `mapping/monikerMapping.json` | Add `azps-100.0.0` entry — `packageRoot`, `conceptualToc`, `serviceMap`. Mirrors the shape of every other moniker in the file. |
| `mapping/az-groupMapping-100.0.0.json` | **New file.** Maps the 24 cmdlets AzClips ships today to service families. First-pass groupings are by shipping module (`Compute`, `Config`, `Accounts`, `MS Graph`, `Resources`) — happy to align with docs.ms conventions if there's a preferred taxonomy. |
| `docs-conceptual/azps-100.0.0/toc.yml` | **New file.** Minimal landing TOC placeholder; conceptual content is not yet authored for AzClips PowerShell. |

### 2. Content commit — `456348b6f`

Produced by the AzClips PS docs sync shim ([Azure/azclips#721](https://github.com/Azure/azclips/pull/721)). Exact invocation from the AzClips repo root:

```powershell
pwsh -File build/Sync-AzclipsPowerShellDocs.ps1 -Force
```

Config file the shim reads ([`build/ps-docs-sync.config.json`](https://github.com/Azure/azclips/blob/main/build/ps-docs-sync.config.json)):

```json
{
  "moniker": "azps-100.0.0",
  "targetRepoPath": "../azure-docs-powershell",
  "targetModuleNamePattern": "Az.{ModuleName}",
  "sourcePsRoot": "src/PS",
  "sourceRepoUrl": "https://github.com/Azure/azclips",
  "sourceBranch": "main",
  "downloadHelpLinkBase": "https://learn.microsoft.com/powershell/module"
}
```

What the shim does:
- Discovers publishable modules under `src/PS/` (any module with both `<Name>.psd1` and a non-empty `help/` directory).
- Generates per-module `Az.<Module>.md` module-index files at sync time from the module manifest + each cmdlet's `## SYNOPSIS`.
- Copies `src/PS/<Module>/help/*.md` (PlatyPS `2024-05-01` schema) into `azps-100.0.0/Az.<Module>/`.
- Commits the branch with a deterministic message. No push (that step is manual pending bot-auth).

## Content shape

29 files across 5 modules:

| Folder | Cmdlets | Notes |
|--------|---------|-------|
| `azps-100.0.0/Az.Compute/` | 3 (`Get-AzVM`, `New-AzVM`, `Remove-AzVM`) | |
| `azps-100.0.0/Az.Config/` | 5 (`Get-AzConfig`, `Get-AzConfigInfo`, `Get-AzConfigList`, `Remove-AzConfig`, `Set-AzConfig`) | AzClips ships `Az.Config` as a distinct module. In real Az PS these live under `Az.Accounts`; happy to remap if that's preferred. |
| `azps-100.0.0/Az.Login/` | 5 (`Connect-AzAccount`, `Disconnect-AzAccount`, `Get-AzProfile`, `Remove-AzProfile`, `Set-AzProfile`) | Same note — AzClips ships `Az.Login`; real Az PS uses `Az.Accounts`. |
| `azps-100.0.0/Az.MsGraph/` | 6 (`Get-AzMsGraphApplication`, `Get-AzMsGraphGroup`, `Get-AzMsGraphGroupMember`, `Get-AzMsGraphUser`, `New-AzMsGraphApplication`, `Remove-AzMsGraphApplication`) | |
| `azps-100.0.0/Az.Resources/` | 5 (`Get-AzResourceGroup`, `Invoke-AzRestMethod`, `New-AzResourceGroup`, `New-AzResourceGroupDeployment`, `New-AzResourceGroupDeploymentWhatIf`) | |

Plus one `Az.<Module>.md` module-index page per folder (5 total).

## Open questions for reviewers

1. **Module folder naming** — we currently ship as `Az.Compute` / `Az.Config` / `Az.Login` / `Az.MsGraph` / `Az.Resources` because those are the AzClips module names. If docs.ms expects the classic Az PS layout (`Az.Accounts` for everything Accounts/Config/Login-related), we can remap the shim's `targetModuleNamePattern` and re-sync.
2. **Service-family groupings** in `az-groupMapping-100.0.0.json` — first-pass is by-module. Guidance welcome if there's a preferred vocabulary (e.g., "Virtual Machines" instead of "Compute").
3. **Conceptual content** — the placeholder `docs-conceptual/azps-100.0.0/toc.yml` is a stub; we don't have onboarding-narrative markdown yet. Is a stub TOC acceptable to unblock the reference-content build, or do we need at least a landing `index.yml`?
4. **`PSMD2Yaml` vs `MAML2Yaml`** — the docset currently uses `MAML2Yaml` (per `.openpublishing.publish.config.json`). Per the docs.ms guidance the AzClips team has seen, new onboardings target `PSMD2Yaml` (PlatyPS `2024-05-01`-compatible). Should this PR flip the docset config, or is that a separate change docs.ms owns?

## Related

- [Azure/azclips#721](https://github.com/Azure/azclips/pull/721) — the PS docs sync shim.
- [Azure/azclips#798](https://github.com/Azure/azclips/pull/798) — the analogous CLI docs sync shim (in review).
- [MicrosoftDocs/azure-docs-cli#6158](https://github.com/MicrosoftDocs/azure-docs-cli/pull/6158) — the parallel CLI-side onboarding PR (script-driven successor to #6153).
